### PR TITLE
Improve build process stability

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -13,16 +13,17 @@ permissions:
 
 jobs:
   report-coverage:
+    if: github.repository == 'btcpay-monero/btcpayserver-monero-plugin' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Download coverage report
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v4
         with:
           name: coverage-report
           github-token: ${{ secrets.API_GITHUB }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: dotcover.xml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,13 +52,13 @@ jobs:
       run: docker compose -f BTCPayServer.Plugins.IntegrationTests/docker-compose.yml down -v
 
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coverage/dotcover.xml
 
     - name: Upload NuGet package
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@v4
       with:
         name: nuget-package-${{ github.sha }}
         path: nuget-packages/BTCPayServer.Plugins.Monero.1.0.0.nupkg

--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
@@ -14,6 +14,7 @@
   <!-- Plugin development properties -->
   <PropertyGroup>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>


### PR DESCRIPTION
Should resolve https://github.com/btcpay-monero/btcpayserver-monero-plugin/actions/runs/15670911571/attempts/1 `/usr/share/dotnet/sdk/8.0.411/Sdks/Microsoft.NET.Sdk.StaticWebAssets/targets/Microsoft.NET.Sdk.StaticWebAssets.Publish.targets(57,5): error : Manifest file at 'obj/Release/net8.0/staticwebassets.build.json' not found.` and Codacy unnecessary builds..