### PR TITLE
Upgrage dotCover from version 2025.1.6 to 2026.1.0.1

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,8 +41,9 @@ jobs:
 
     - name: Run unit tests
       run: |
-        dotnet tool install --global JetBrains.dotCover.CommandLineTools --version 2025.1.8
-        dotCover cover-dotnet --TargetArguments="test BTCPayServer.Plugins.UnitTests -c Release --no-build -v n" --output=coverage/dotCover.UnitTests.output.dcvr --filters="-:Assembly=BTCPayServer.Plugins.UnitTests;-:Assembly=testhost;-:Assembly=BTCPayServer;-:Class=AspNetCoreGeneratedDocument.*"
+        mkdir -p coverage
+        dotnet tool install --global JetBrains.dotCover.CommandLineTools --version 2026.1.0.1 
+        dotCover cover --target-working-directory . --snapshot-output $(pwd)/coverage/dotCover.UnitTests.dcvr -- dotnet test BTCPayServer.Plugins.UnitTests -c Release --no-build
 
     - name: Run integration tests
       run: docker compose -f BTCPayServer.Plugins.IntegrationTests/docker-compose.yml run tests

--- a/BTCPayServer.Plugins.IntegrationTests/BTCPayServer.Plugins.IntegrationTests.csproj
+++ b/BTCPayServer.Plugins.IntegrationTests/BTCPayServer.Plugins.IntegrationTests.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Microsoft.Playwright" Version="1.57.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/BTCPayServer.Plugins.IntegrationTests/Dockerfile
+++ b/BTCPayServer.Plugins.IntegrationTests/Dockerfile
@@ -21,8 +21,8 @@ COPY ../submodules/btcpayserver/BTCPayServer.Abstractions/. BTCPayServer.Abstrac
 COPY ../submodules/btcpayserver/BTCPayServer/. BTCPayServer/.
 COPY ../submodules/btcpayserver/Build/Version.csproj Build/Version.csproj
 
-ENV SCREEN_HEIGHT 600 \
-    SCREEN_WIDTH 1200
+ENV SCREEN_HEIGHT=600 \
+    SCREEN_WIDTH=1200
 
 COPY . .
 
@@ -31,7 +31,7 @@ ARG MONERO_PLUGIN_FOLDER=/root/.btcpayserver/Plugins/BTCPayServer.Plugins.Monero
 RUN mkdir -p ${MONERO_PLUGIN_FOLDER}
 RUN cd Plugins/Monero && dotnet build BTCPayServer.Plugins.Monero.sln --configuration ${CONFIGURATION_NAME} /p:RazorCompileOnBuild=true --output ${MONERO_PLUGIN_FOLDER}
 RUN cd BTCPayServer.Plugins.IntegrationTests && dotnet build --configuration ${CONFIGURATION_NAME} /p:CI_TESTS=true /p:RazorCompileOnBuild=true
-RUN dotnet tool install --global JetBrains.DotCover.CommandLineTools --version 2025.1.8
+RUN dotnet tool install --global JetBrains.DotCover.CommandLineTools --version 2026.1.0.1
 ENV PATH="$PATH:/root/.dotnet/tools"
 RUN pwsh /source/BTCPayServer.Plugins.IntegrationTests/bin/Release/net8.0/playwright.ps1 install chromium --with-deps
 WORKDIR /source/BTCPayServer.Plugins.IntegrationTests

--- a/BTCPayServer.Plugins.IntegrationTests/docker-entrypoint.sh
+++ b/BTCPayServer.Plugins.IntegrationTests/docker-entrypoint.sh
@@ -1,28 +1,18 @@
 #!/bin/sh
 set -e
 
-dotCover cover-dotnet \
-  --TargetArguments="test -c ${CONFIGURATION_NAME} --no-build -v n" \
-  --Output=/coverage/dotCover.IntegrationTests.output.dcvr \
-  --filters="-:Assembly=BTCPayServer.Plugins.IntegrationTests;-:Assembly=Monero;-:Assembly=testhost;-:Assembly=BTCPayServer;-:Assembly=ExchangeSharp;-:Assembly=BTCPayServer.Tests;-:Assembly=BTCPayServer.Client;-:Assembly=BTCPayServer.Abstractions;-:Assembly=BTCPayServer.Data;-:Assembly=BTCPayServer.Common;-:Assembly=BTCPayServer.Logging;-:Assembly=BTCPayServer.Rating;-:Assembly=Dapper;-:Assembly=Serilog.Extensions.Logging;-:Class=AspNetCoreGeneratedDocument.*"
+dotCover cover \
+  --target-working-directory . \
+  --snapshot-output /coverage/dotCover.IntegrationTests.dcvr \
+  -- dotnet test -c Release . --no-build
+#  TODO: apply filters
+#  --filters="-:Assembly=BTCPayServer.Plugins.IntegrationTests;-:Assembly=testhost;-:Assembly=BTCPayServer;-:Assembly=ExchangeSharp;-:Assembly=BTCPayServer.Tests;-:Assembly=BTCPayServer.Client;-:Assembly=BTCPayServer.Abstractions;-:Assembly=BTCPayServer.Data;-:Assembly=BTCPayServer.Common;-:Assembly=BTCPayServer.Logging;-:Assembly=BTCPayServer.Rating;-:Assembly=Dapper;-:Assembly=Serilog.Extensions.Logging;-:Class=AspNetCoreGeneratedDocument.*"
 
 dotCover merge \
-  --Source=/coverage/dotCover.IntegrationTests.output.dcvr,/coverage/dotCover.UnitTests.output.dcvr \
-  --Output=/coverage/mergedCoverage.dcvr
+  --snapshot-source /coverage/dotCover.IntegrationTests.dcvr,/coverage/dotCover.UnitTests.dcvr \
+  --snapshot-output /coverage/mergedCoverage.dcvr
 
 dotCover report \
-  --Source=/coverage/mergedCoverage.dcvr \
-  --ReportType=HTML \
-  --Output=/coverage/mergedCoverage.html \
-  --ReportType=DetailedXML \
-  --Output=/coverage/dotcover.xml
-  
-dotCover report \
-  --Source=/coverage/dotCover.UnitTests.output.dcvr \
-  --ReportType=HTML \
-  --Output=/coverage/unitCoverage.html
-  
-dotCover report \
-  --Source=/coverage/dotCover.IntegrationTests.output.dcvr \
-  --ReportType=HTML \
-  --Output=/coverage/integrationCoverage.html
+  --snapshot-source /coverage/mergedCoverage.dcvr \
+  --xml-report-output /coverage/dotcover.xml \
+  --log-file /coverage/logfile.txt

--- a/BTCPayServer.Plugins.UnitTests/BTCPayServer.Plugins.UnitTests.csproj
+++ b/BTCPayServer.Plugins.UnitTests/BTCPayServer.Plugins.UnitTests.csproj
@@ -19,10 +19,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ dotnet test BTCPayServer.Plugins.UnitTests --verbosity normal
 To run unit tests with coverage, install JetBrains dotCover CLI:
 
 ```bash
-dotnet tool install --global JetBrains.dotCover.CommandLineTools --version 2025.1.8
+dotnet tool install --global JetBrains.dotCover.CommandLineTools --version 2026.1.0.1
 ```
 Then run the following command:
 
 ```bash
-dotCover cover-dotnet --TargetArguments="test BTCPayServer.Plugins.UnitTests --no-build" --ReportType=HTML --Output=coverage/dotCover.UnitTests.output.html --ReportType=detailedXML --Output=coverage/dotCover.UnitTests.output.xml --filters="-:Assembly=BTCPayServer.Plugins.UnitTests;-:Assembly=testhost;-:Assembly=BTCPayServer;-:Class=AspNetCoreGeneratedDocument.*"
+dotCover cover --target-working-directory . --snapshot-output $(pwd)/coverage/dotCover.UnitTests.dcvr -- dotnet test BTCPayServer.Plugins.UnitTests -c Release --no-build
 ```
 
 To build and run integration tests, run the following commands:
@@ -99,7 +99,7 @@ Then create the `appsettings.dev.json` file in `btcpayserver/BTCPayServer`, with
 
 ```json
 {
-  "DEBUG_PLUGINS": "..\\..\\Plugins\\Monero\\bin\\Debug\\net8.0\\BTCPayServer.Plugins.Monero.dll",
+  "DEBUG_PLUGINS": "..\\..\\Plugins\\Monero\\bin\\Debug\\net10.0\\BTCPayServer.Plugins.Monero.dll",
   "XMR_DAEMON_URI": "http://127.0.0.1:18081",
   "XMR_WALLET_DAEMON_URI": "http://127.0.0.1:18082"
 }


### PR DESCRIPTION
This PR is intentionally left as draft to document the problem that upgrading dotCover from `2025.1.x` to `2025.2.x` and above (tested with `2025.3.3`) is currently not possible in our setup. While generating the coverage report the process hangs indefinitely. 

This behavior appears to match the issue reported by JetBrains: https://youtrack.jetbrains.com/issue/DCVR-13363/Generating-Report-with-CLI-2026.1-EAP-1-hangs