### PR TITLE
Rename installed plugin tab title to Monero

### DIFF
--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
@@ -6,7 +6,7 @@
 
   <!-- Plugin specific properties -->
   <PropertyGroup>
-    <Product>BTCPay Server: Monero support plugin</Product>
+    <Product>Monero</Product>
     <Description>This plugin extends BTCPay Server to enable users to receive payments via Monero.</Description>
     <Version>1.1.0</Version>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.json
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.json
@@ -1,6 +1,6 @@
 {
   "Identifier": "BTCPayServer.Plugins.Monero",
-  "Name": "BTCPay Server: Monero support plugin",
+  "Name": "Monero",
   "Version": "1.1.0",
   "Description": "This plugin extends BTCPay Server to enable users to receive payments via Monero.",
   "SystemPlugin": false,


### PR DESCRIPTION
Renaming `BTCPay Server: Monero support plugin` to simply `Monero`

<img width="495" height="464" alt="image" src="https://github.com/user-attachments/assets/c7184c88-6a06-41cd-ac2c-3e463dc81362" />
