### PR TITLE
Password deprecation

### DIFF
--- a/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
+++ b/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
@@ -11,6 +11,9 @@ namespace BTCPayServer.Plugins.IntegrationTests.Monero;
 
 public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroIntegrationTestBase(helper)
 {
+    private const string PrimaryWalletAddress = "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L";
+    private const string PrimaryViewKey = "1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e";
+
     [Fact]
     public async Task ShouldEnableMoneroPluginSuccessfully()
     {
@@ -38,11 +41,8 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.RegisterNewUser(true);
         await s.CreateNewStore(preferredExchange: "Kraken");
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
-        await s.Page.Locator("input#PrimaryAddress")
-            .FillAsync(
-                "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
-        await s.Page.Locator("input#PrivateViewKey")
-            .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
+        await s.Page.Locator("input#PrimaryAddress").FillAsync(PrimaryWalletAddress);
+        await s.Page.Locator("input#PrivateViewKey").FillAsync(PrimaryViewKey);
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
         await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
         var message = await s.Page
@@ -120,8 +120,7 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
         await s.Page.Locator("input#PrimaryAddress")
             .FillAsync("wrongprimaryaddressfSF6ZKGFT7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
-        await s.Page.Locator("input#PrivateViewKey")
-            .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
+        await s.Page.Locator("input#PrivateViewKey").FillAsync(PrimaryViewKey);
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
         await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
         var errorText = await s.Page
@@ -142,9 +141,8 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
             .SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys",
                 new GenerateFromKeysRequest
                 {
-                    PrimaryAddress =
-                        "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L",
-                    PrivateViewKey = "1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e",
+                    PrimaryAddress = PrimaryWalletAddress,
+                    PrivateViewKey = PrimaryViewKey,
                     WalletFileName = "wallet",
                     Password = ""
                 }, TestContext.Current.CancellationToken);
@@ -153,10 +151,8 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.RegisterNewUser(true);
         await s.CreateNewStore();
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
-        await s.Page.Locator("input#PrimaryAddress")
-            .FillAsync("43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
-        await s.Page.Locator("input#PrivateViewKey")
-            .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
+        await s.Page.Locator("input#PrimaryAddress").FillAsync(PrimaryWalletAddress);
+        await s.Page.Locator("input#PrivateViewKey").FillAsync(PrimaryViewKey);
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
         await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
         var errorText = await s.Page
@@ -189,7 +185,7 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         SkipUnless = nameof(IntegrationTestUtils.RunsInContainer),
         SkipType = typeof(IntegrationTestUtils)
     )]
-    public async Task ShouldLoadViewWalletWithPasswordOnStartUpIfExists()
+    public async Task CompleteMigratePasswordFromFile()
     {
         await IntegrationTestUtils.CreateTestXmrWalletWithPasswordAsync("pass123", "wallet_password");
         await IntegrationTestUtils.CloseTestXmrWalletFilesViaRpc();
@@ -204,5 +200,8 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
             .InnerTextAsync();
 
         Assert.Contains("Wallet RPC available: True", walletRpcIsAvailable);
+
+        var warningText = await s.Page.Locator("div.alert.alert-warning").InnerTextAsync();
+        Assert.Contains("Password file deprecation complete.", warningText);
     }
 }

--- a/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
+++ b/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
@@ -128,6 +128,7 @@ namespace BTCPayServer.Plugins.Monero.Controllers
                 AccountIndex = settings?.AccountIndex ?? accountsResponse?.Accounts?.FirstOrDefault()?.AccountIndex ?? 0,
                 Accounts = accounts == null ? null : new SelectList(accounts, nameof(SelectListItem.Value),
                     nameof(SelectListItem.Text)),
+                HasDeprecatedPasswordFile = _MoneroRpcProvider.HasDeprecatedPasswordFile(cryptoCode),
                 SettlementConfirmationThresholdChoice = settlementThresholdChoice,
                 CustomSettlementConfirmationThreshold =
                     settings != null &&
@@ -285,6 +286,7 @@ namespace BTCPayServer.Plugins.Monero.Controllers
 
             public IEnumerable<SelectListItem> Accounts { get; set; }
             public bool WalletFileFound { get; set; }
+            public bool HasDeprecatedPasswordFile { get; set; }
             [Display(Name = "Primary Public Address")]
             public string PrimaryAddress { get; set; }
             [Display(Name = "Private View Key")]

--- a/Plugins/Monero/Services/MoneroLoadUpService.cs
+++ b/Plugins/Monero/Services/MoneroLoadUpService.cs
@@ -6,9 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-using Monero.Daemon.Common;
-using Monero.Wallet.Rpc;
-
 namespace BTCPayServer.Plugins.Monero.Services;
 
 public class MoneroLoadUpService : IHostedService
@@ -23,7 +20,6 @@ public class MoneroLoadUpService : IHostedService
         _logger = logger;
     }
 
-    [Obsolete("Remove optional password parameter")]
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         try
@@ -31,20 +27,20 @@ public class MoneroLoadUpService : IHostedService
             _logger.LogInformation("Attempt to load existing wallet");
 
             string walletDir = _moneroRpcProvider.GetWalletDirectory(CryptoCode);
+            string passwordFile = Path.Combine(walletDir, "password");
             if (!string.IsNullOrEmpty(walletDir))
             {
-                string password = await TryToGetPassword(walletDir, cancellationToken);
-
-                await _moneroRpcProvider.WalletRpcClients[CryptoCode]
-                    .SendCommandAsync<OpenWalletRequest, MoneroRpcResponse>("open_wallet",
-                        new OpenWalletRequest { Filename = "wallet", Password = password }, cancellationToken);
-
+                if (File.Exists(passwordFile))
+                {
+                    await TryDeprecatePasswordFile(passwordFile);
+                }
+                await _moneroRpcProvider.OpenWallet(CryptoCode, "wallet", "");
                 await _moneroRpcProvider.UpdateSummary(CryptoCode);
                 _logger.LogInformation("Existing wallet successfully loaded");
             }
             else
             {
-                _logger.LogInformation("No wallet directory configured, skipping wallet migration");
+                _logger.LogInformation("No wallet configured, skipping wallet migration");
             }
         }
         catch (Exception ex)
@@ -54,22 +50,20 @@ public class MoneroLoadUpService : IHostedService
         }
     }
 
-    [Obsolete("Password is obsolete due to the inability to fully separate the password file from the wallet file.")]
-    private async Task<string> TryToGetPassword(string walletDir, CancellationToken cancellationToken)
+    private async Task TryDeprecatePasswordFile(string passwordFile)
     {
-        string password = "";
-        string passwordFile = Path.Combine(walletDir, "password");
-        if (File.Exists(passwordFile))
+        try
         {
-            password = await File.ReadAllTextAsync(passwordFile, cancellationToken);
-            password = password.Trim();
+            string password = (await File.ReadAllTextAsync(passwordFile));
+            await _moneroRpcProvider.OpenWallet(CryptoCode, "wallet", password);
+            await _moneroRpcProvider.ChangeWalletPassword(CryptoCode, password, "");
+            await _moneroRpcProvider.CloseWallet(CryptoCode);
+            _logger.LogInformation("Successfully migrated wallet to remove password");
         }
-        else
+        catch (Exception ex)
         {
-            _logger.LogInformation("No password file found - ignoring");
+            _logger.LogError(ex, "Error during wallet password deprecation");
         }
-
-        return password;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/Plugins/Monero/Services/MoneroRpcProvider.cs
+++ b/Plugins/Monero/Services/MoneroRpcProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -52,6 +53,21 @@ namespace BTCPayServer.Plugins.Monero.Services
                    summary.WalletAvailable;
         }
 
+        public async Task OpenWallet(string cryptoCode, string filename, string password)
+        {
+            if (!WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
+            {
+                throw new InvalidOperationException($"Wallet RPC client not found for {cryptoCode}");
+            }
+
+            await walletRpcClient.SendCommandAsync<OpenWalletRequest, object>(
+                "open_wallet", new OpenWalletRequest
+                {
+                    Filename = filename,
+                    Password = password
+                });
+        }
+
         public async Task CloseWallet(string cryptoCode)
         {
             if (!WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
@@ -63,12 +79,38 @@ namespace BTCPayServer.Plugins.Monero.Services
                 "close_wallet", NoRequestModel.Instance);
         }
 
+        public async Task ChangeWalletPassword(string cryptoCode, string oldPassword, string newPassword)
+        {
+            if (!WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
+            {
+                throw new InvalidOperationException($"Wallet RPC client not found for {cryptoCode}");
+            }
+
+            await walletRpcClient.SendCommandAsync<object, MoneroRpcResponse>(
+                "change_wallet_password", new
+                {
+                    old_password = oldPassword,
+                    new_password = newPassword
+                });
+        }
+
         public string GetWalletDirectory(string cryptoCode)
         {
             cryptoCode = cryptoCode.ToUpperInvariant();
             return !_moneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode, out var configItem)
                 ? null
                 : configItem.WalletDirectory;
+        }
+
+        public bool HasDeprecatedPasswordFile(string cryptoCode)
+        {
+            string walletDir = GetWalletDirectory(cryptoCode);
+            if (string.IsNullOrEmpty(walletDir))
+            {
+                return false;
+            }
+
+            return File.Exists(Path.Combine(walletDir, "password"));
         }
 
         public async Task<MoneroLikeSummary> UpdateSummary(string cryptoCode)

--- a/Plugins/Monero/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml
+++ b/Plugins/Monero/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml
@@ -9,6 +9,14 @@
 
 <partial name="_StatusMessage" />
 
+@if (Model.HasDeprecatedPasswordFile)
+{
+    <div class="alert alert-warning" role="alert">
+        <strong>Password file deprecation complete.</strong>
+        The wallet password has been removed. Please delete the password file from your wallet directory to complete the deprecation.
+    </div>
+}
+
 <div class="row">
     <div class="col-md-8">
         @if (!ViewContext.ModelState.IsValid)


### PR DESCRIPTION
This feature deprecates password file for all wallets. 

**Major Changes Included:**

- Password File deprecated and all wallets migrated to passwordless

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a Bootstrap warning alert on the Monero “wallet” setup screen when a deprecated password file is detected, with instructions to delete it after migration.

* **Bug Fixes**
  * Improved Monero wallet startup to support password-file deprecation: it now uses RPC-backed opening and updates wallet summary after handling the legacy file.

* **Tests**
  * Updated and renamed Monero plugin integration tests to validate migration behavior, wrong-credentials scenarios, and the new warning messaging using shared primary wallet constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->