### PR TITLE
fix: bump the plugin version

### DIFF
--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.json
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.json
@@ -1,7 +1,7 @@
 {
   "Identifier": "BTCPayServer.Plugins.Monero",
   "Name": "Monero",
-  "Version": "1.1.0",
+  "Version": "1.2.0",
   "Description": "This plugin extends BTCPay Server to enable users to receive payments via Monero.",
   "SystemPlugin": false,
   "Dependencies": [


### PR DESCRIPTION
Hello,

I was reviewing the diff between v1.1.0 and v1.2.0 and saw this line was left to "1.1.0".

Maybe this is the way it should be (and if so, forgive me!), but anyway I open the PR to be sure this is expected to remain "1.1.0".