### PR TITLE
Switch to Coverlet for test coverage and replace dotCover

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -26,4 +26,4 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: dotcover.xml
+          coverage-reports: Cobertura.xml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,9 +40,7 @@ jobs:
         dotnet validate package local nuget-packages/BTCPayServer.Plugins.Monero.1.0.0.nupkg
 
     - name: Run unit tests
-      run: |
-        dotnet tool install --global JetBrains.dotCover.CommandLineTools --version 2025.1.8
-        dotCover cover-dotnet --TargetArguments="test BTCPayServer.Plugins.UnitTests -c Release --no-build -v n" --output=coverage/dotCover.UnitTests.output.dcvr --filters="-:Assembly=BTCPayServer.Plugins.UnitTests;-:Assembly=testhost;-:Assembly=BTCPayServer;-:Class=AspNetCoreGeneratedDocument.*"
+      run: dotnet test BTCPayServer.Plugins.UnitTests -c Release --no-build -v n /p:CollectCoverage=true /p:CoverletOutput=../coverage/unit/ /p:CoverletOutputFormat=cobertura /p:Include="[BTCPayServer.Plugins.Monero*]*"
 
     - name: Run integration tests
       run: docker compose -f BTCPayServer.Plugins.IntegrationTests/docker-compose.yml run tests
@@ -55,7 +53,7 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: coverage-report
-        path: coverage/dotcover.xml
+        path: coverage/merged/Cobertura.xml
 
     - name: Upload NuGet package
       uses: actions/upload-artifact@v6

--- a/BTCPayServer.Plugins.IntegrationTests/Dockerfile
+++ b/BTCPayServer.Plugins.IntegrationTests/Dockerfile
@@ -31,7 +31,7 @@ ARG MONERO_PLUGIN_FOLDER=/root/.btcpayserver/Plugins/BTCPayServer.Plugins.Monero
 RUN mkdir -p ${MONERO_PLUGIN_FOLDER}
 RUN cd Plugins/Monero && dotnet build BTCPayServer.Plugins.Monero.sln --configuration ${CONFIGURATION_NAME} /p:RazorCompileOnBuild=true --output ${MONERO_PLUGIN_FOLDER}
 RUN cd BTCPayServer.Plugins.IntegrationTests && dotnet build --configuration ${CONFIGURATION_NAME} /p:CI_TESTS=true /p:RazorCompileOnBuild=true
-RUN dotnet tool install --global JetBrains.DotCover.CommandLineTools --version 2025.1.8
+RUN dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.5.4
 ENV PATH="$PATH:/root/.dotnet/tools"
 RUN pwsh /source/BTCPayServer.Plugins.IntegrationTests/bin/Release/net8.0/playwright.ps1 install chromium --with-deps
 WORKDIR /source/BTCPayServer.Plugins.IntegrationTests

--- a/BTCPayServer.Plugins.IntegrationTests/docker-entrypoint.sh
+++ b/BTCPayServer.Plugins.IntegrationTests/docker-entrypoint.sh
@@ -1,28 +1,9 @@
 #!/bin/sh
 set -e
 
-dotCover cover-dotnet \
-  --TargetArguments="test -c ${CONFIGURATION_NAME} --no-build -v n" \
-  --Output=/coverage/dotCover.IntegrationTests.output.dcvr \
-  --filters="-:Assembly=BTCPayServer.Plugins.IntegrationTests;-:Assembly=Monero;-:Assembly=testhost;-:Assembly=BTCPayServer;-:Assembly=ExchangeSharp;-:Assembly=BTCPayServer.Tests;-:Assembly=BTCPayServer.Client;-:Assembly=BTCPayServer.Abstractions;-:Assembly=BTCPayServer.Data;-:Assembly=BTCPayServer.Common;-:Assembly=BTCPayServer.Logging;-:Assembly=BTCPayServer.Rating;-:Assembly=Dapper;-:Assembly=Serilog.Extensions.Logging;-:Class=AspNetCoreGeneratedDocument.*"
+dotnet test -c ${CONFIGURATION_NAME} --no-build -v n /p:CollectCoverage=true /p:CoverletOutput=/coverage/integration/ /p:CoverletOutputFormat=cobertura /p:Include="[BTCPayServer.Plugins.Monero*]*"
 
-dotCover merge \
-  --Source=/coverage/dotCover.IntegrationTests.output.dcvr,/coverage/dotCover.UnitTests.output.dcvr \
-  --Output=/coverage/mergedCoverage.dcvr
-
-dotCover report \
-  --Source=/coverage/mergedCoverage.dcvr \
-  --ReportType=HTML \
-  --Output=/coverage/mergedCoverage.html \
-  --ReportType=DetailedXML \
-  --Output=/coverage/dotcover.xml
-  
-dotCover report \
-  --Source=/coverage/dotCover.UnitTests.output.dcvr \
-  --ReportType=HTML \
-  --Output=/coverage/unitCoverage.html
-  
-dotCover report \
-  --Source=/coverage/dotCover.IntegrationTests.output.dcvr \
-  --ReportType=HTML \
-  --Output=/coverage/integrationCoverage.html
+reportgenerator \
+  -reports:"/coverage/unit/coverage.cobertura.xml;/coverage/integration/coverage.cobertura.xml" \
+  -targetdir:"/coverage/merged" \
+  -reporttypes:"HtmlSummary;Cobertura"

--- a/BTCPayServer.Plugins.UnitTests/BTCPayServer.Plugins.UnitTests.csproj
+++ b/BTCPayServer.Plugins.UnitTests/BTCPayServer.Plugins.UnitTests.csproj
@@ -11,13 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
+        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="Moq" Version="4.20.72" />

--- a/README.md
+++ b/README.md
@@ -65,15 +65,10 @@ To build and run unit tests, run the following commands:
 dotnet build btcpay-monero-plugin.sln
 dotnet test BTCPayServer.Plugins.UnitTests --verbosity normal
 ```
-To run unit tests with coverage, install JetBrains dotCover CLI:
+To run unit tests with coverage, run the following command:
 
 ```bash
-dotnet tool install --global JetBrains.dotCover.CommandLineTools --version 2025.1.8
-```
-Then run the following command:
-
-```bash
-dotCover cover-dotnet --TargetArguments="test BTCPayServer.Plugins.UnitTests --no-build" --ReportType=HTML --Output=coverage/dotCover.UnitTests.output.html --ReportType=detailedXML --Output=coverage/dotCover.UnitTests.output.xml --filters="-:Assembly=BTCPayServer.Plugins.UnitTests;-:Assembly=testhost;-:Assembly=BTCPayServer;-:Class=AspNetCoreGeneratedDocument.*"
+dotnet test BTCPayServer.Plugins.UnitTests -v n /p:CollectCoverage=true /p:CoverletOutput=../coverage/unit/ /p:CoverletOutputFormat=cobertura /p:Include="[BTCPayServer.Plugins.Monero*]*"
 ```
 
 To build and run integration tests, run the following commands:


### PR DESCRIPTION
This PR is somewhat difficult to review due to inconsistencies between code coverage tools. Specifically, [dotCover](https://www.jetbrains.com/dotcover/) and [Coverlet](https://github.com/coverlet-coverage/coverlet) report different coverage results, as they rely on different coverage mechanisms.

Additionally, it appears that the `Cobertura.xml` report is not being considered by Codacy unless the changes are merged into the `master` branch.

Given these limitations, it seems the most practical approach is to proceed and try it out in practice to verify how coverage is reported after merging.

https://docs.codacy.com/coverage-reporter/#generating-coverage