### PR TITLE
Remove DisableRequestSizeLimit from GetStoreMoneroLikePaymentMethod

### DIFF
--- a/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
+++ b/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
@@ -149,7 +149,6 @@ namespace BTCPayServer.Plugins.Monero.Controllers
         }
 
         [HttpPost("{cryptoCode}")]
-        [DisableRequestSizeLimit]
         public async Task<IActionResult> GetStoreMoneroLikePaymentMethod(MoneroLikePaymentMethodViewModel viewModel, string command, string cryptoCode)
         {
             cryptoCode = cryptoCode.ToUpperInvariant();


### PR DESCRIPTION
DisableRequestSizeLimit was used for wallet file uploads and can now be removed