### PR TITLE
Refactor wallet setup

### DIFF
--- a/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
+++ b/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
@@ -1,9 +1,6 @@
-using BTCPayServer.Plugins.Monero.Services;
 using BTCPayServer.Rating;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Tests.Mocks;
-
-using Monero.Wallet.Rpc;
 
 using Xunit;
 using Xunit.Abstractions;
@@ -39,15 +36,16 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.RegisterNewUser(true);
         await s.CreateNewStore(preferredExchange: "Kraken");
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
+        await s.Page.Locator("#ConnectWalletLink").ClickAsync();
         await s.Page.Locator("input#PrimaryAddress")
             .FillAsync(
                 "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
         await s.Page.Locator("input#PrivateViewKey")
             .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
-        await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
+        await s.Page.ClickAsync("#ConnectWalletButton");
         var message = await s.Page
-            .GetByText("View-only wallet created. The wallet will soon become available.")
+            .GetByText("View-only wallet created and now active")
             .InnerTextAsync();
         Assert.Contains("View-only wallet created", message);
         await Task.Delay(TimeSpan.FromSeconds(5)); // wallet-rpc needs some time to create wallet files. refactor this later
@@ -88,17 +86,9 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.Page.GoBackAsync();
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
 
-        // Create a new account label
         await s.Page.FillAsync("#NewAccountLabel", "tst-account");
-        await s.Page.ClickAsync("button[name='command'][value='add-account']");
+        await s.Page.ClickAsync("#AddAccountButton");
 
-        // Select primary Account Index
-        await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
-        await s.Page.SelectOptionAsync("#AccountIndex", "1");
-        await s.Page.ClickAsync("#SaveButton");
-
-        // Verify selected account index
-        await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
         var selectedValue = await s.Page.Locator("#AccountIndex").InputValueAsync();
         Assert.Equal("1", selectedValue);
 
@@ -116,49 +106,18 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.RegisterNewUser(true);
         await s.CreateNewStore();
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
+        await s.Page.Locator("#ConnectWalletLink").ClickAsync();
         await s.Page.Locator("input#PrimaryAddress")
             .FillAsync("wrongprimaryaddressfSF6ZKGFT7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
         await s.Page.Locator("input#PrivateViewKey")
             .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
-        await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
+        await s.Page.ClickAsync("#ConnectWalletButton");
         var errorText = await s.Page
             .Locator("div.validation-summary-errors li")
             .InnerTextAsync();
 
         Assert.Equal("Could not generate view wallet from keys: Failed to parse public address", errorText);
-    }
-
-    [Fact]
-    public async Task ShouldFailWhenWalletFileAlreadyExists()
-    {
-        await using var s = CreatePlaywrightTester();
-        await s.StartAsync();
-
-        MoneroRpcProvider moneroRpcProvider = s.Server.PayTester.GetService<MoneroRpcProvider>();
-        await moneroRpcProvider.WalletRpcClients["XMR"].SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys", new GenerateFromKeysRequest
-        {
-            PrimaryAddress = "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L",
-            PrivateViewKey = "1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e",
-            WalletFileName = "wallet",
-            Password = ""
-        });
-        await moneroRpcProvider.CloseWallet("XMR");
-
-        await s.RegisterNewUser(true);
-        await s.CreateNewStore();
-        await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
-        await s.Page.Locator("input#PrimaryAddress")
-            .FillAsync("43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
-        await s.Page.Locator("input#PrivateViewKey")
-            .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
-        await s.Page.Locator("input#RestoreHeight").FillAsync("0");
-        await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
-        var errorText = await s.Page
-            .Locator("div.validation-summary-errors li")
-            .InnerTextAsync();
-
-        Assert.Equal("Could not generate view wallet from keys: Wallet already exists.", errorText);
     }
 
     [Fact]

--- a/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
+++ b/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
@@ -99,8 +99,6 @@ namespace BTCPayServer.Plugins.Monero.Controllers
             var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
             var settings = monero.Where(method => method.PaymentMethodId == pmi).Select(m => m.Details).SingleOrDefault();
             _MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary);
-            _MoneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode,
-                out var configurationItem);
             var accounts = accountsResponse?.Accounts.Select(account =>
                 new SelectListItem(
                     $"{account.AccountIndex} - {(string.IsNullOrEmpty(account.Label) ? "No label" : account.Label)}",
@@ -146,93 +144,24 @@ namespace BTCPayServer.Plugins.Monero.Controllers
                 return NotFound();
             }
 
+            if (!_MoneroRpcProvider.WalletFileExists(cryptoCode))
+            {
+                return RedirectToAction(nameof(WalletSetup), new { storeId = StoreData.Id, cryptoCode });
+            }
+
             var vm = GetMoneroLikePaymentMethodViewModel(StoreData, cryptoCode,
                 StoreData.GetStoreBlob().GetExcludedPaymentMethods(), await GetAccounts(cryptoCode));
             return View("/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml", vm);
         }
 
         [HttpPost("{cryptoCode}")]
-        public async Task<IActionResult> GetStoreMoneroLikePaymentMethod(MoneroLikePaymentMethodViewModel viewModel, string command, string cryptoCode)
+        public async Task<IActionResult> GetStoreMoneroLikePaymentMethod(MoneroLikePaymentMethodViewModel viewModel, string cryptoCode)
         {
             cryptoCode = cryptoCode.ToUpperInvariant();
             if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode,
-                out var configurationItem))
+                    out var configurationItem))
             {
                 return NotFound();
-            }
-
-            if (command == "add-account")
-            {
-                try
-                {
-                    var newAccount = await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<CreateAccountRequest, CreateAccountResponse>("create_account", new CreateAccountRequest()
-                    {
-                        Label = viewModel.NewAccountLabel
-                    });
-                    viewModel.AccountIndex = newAccount.AccountIndex;
-                }
-                catch (Exception)
-                {
-                    ModelState.AddModelError(nameof(viewModel.AccountIndex), StringLocalizer["Could not create a new account."]);
-                }
-
-            }
-            else if (command == "set-wallet-details")
-            {
-                var valid = true;
-                if (viewModel.PrimaryAddress == null)
-                {
-                    ModelState.AddModelError(nameof(viewModel.PrimaryAddress), StringLocalizer["Please set your primary public address"]);
-                    valid = false;
-                }
-                if (viewModel.PrivateViewKey == null)
-                {
-                    ModelState.AddModelError(nameof(viewModel.PrivateViewKey), StringLocalizer["Please set your private view key"]);
-                    valid = false;
-                }
-                if (configurationItem.WalletDirectory == null)
-                {
-                    ModelState.AddModelError(nameof(viewModel.PrimaryAddress), StringLocalizer["This installation doesn't support wallet creation (BTCPAY_XMR_WALLET_DAEMON_WALLETDIR is not set)"]);
-                    valid = false;
-                }
-                if (valid)
-                {
-                    if (_MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary))
-                    {
-                        if (summary.WalletAvailable)
-                        {
-                            TempData.SetStatusMessageModel(new StatusMessageModel
-                            {
-                                Severity = StatusMessageModel.StatusSeverity.Error,
-                                Message = StringLocalizer["There is already an active wallet configured for {0}. Replacing it would break any existing invoices!", cryptoCode].Value
-                            });
-                            return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod),
-                                new { cryptoCode });
-                        }
-                    }
-                    try
-                    {
-                        await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys", new GenerateFromKeysRequest
-                        {
-                            PrimaryAddress = viewModel.PrimaryAddress,
-                            PrivateViewKey = viewModel.PrivateViewKey,
-                            WalletFileName = "wallet",
-                            RestoreHeight = viewModel.RestoreHeight
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        ModelState.AddModelError(nameof(viewModel.AccountIndex), StringLocalizer["Could not generate view wallet from keys: {0}", ex.Message]);
-                        return View("/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml", viewModel);
-                    }
-
-                    TempData.SetStatusMessageModel(new StatusMessageModel
-                    {
-                        Severity = StatusMessageModel.StatusSeverity.Info,
-                        Message = StringLocalizer["View-only wallet created. The wallet will soon become available."].Value
-                    });
-                    return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { cryptoCode });
-                }
             }
 
             if (!ModelState.IsValid)
@@ -267,7 +196,142 @@ namespace BTCPayServer.Plugins.Monero.Controllers
             blob.SetExcluded(PaymentTypes.CHAIN.GetPaymentMethodId(viewModel.CryptoCode), !viewModel.Enabled);
             storeData.SetStoreBlob(blob);
             await _StoreRepository.UpdateStore(storeData);
-            return RedirectToAction("GetStoreMoneroLikePaymentMethod", new { cryptoCode });
+            return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { storeId = StoreData.Id, cryptoCode });
+        }
+
+        [HttpPost("accounts/{cryptoCode}")]
+        public async Task<IActionResult> AddAccount(string cryptoCode, MoneroLikePaymentMethodViewModel viewModel)
+        {
+            cryptoCode = cryptoCode.ToUpperInvariant();
+            if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.ContainsKey(cryptoCode))
+            {
+                return NotFound();
+            }
+
+            CreateAccountResponse newAccount;
+            try
+            {
+                newAccount = await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<CreateAccountRequest, CreateAccountResponse>("create_account", new CreateAccountRequest
+                {
+                    Label = viewModel.NewAccountLabel
+                });
+            }
+            catch (Exception ex)
+            {
+                TempData.SetStatusMessageModel(new StatusMessageModel
+                {
+                    Severity = StatusMessageModel.StatusSeverity.Error,
+                    Message = StringLocalizer["Could not create a new account: {0}", ex.Message].Value
+                });
+                return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { storeId = StoreData.Id, cryptoCode });
+            }
+
+            var storeData = StoreData;
+            var pmi = PaymentTypes.CHAIN.GetPaymentMethodId(cryptoCode);
+            var existing = storeData.GetPaymentMethodConfig<MoneroPaymentPromptDetails>(pmi, _handlers);
+            storeData.SetPaymentMethodConfig(_handlers[pmi], new MoneroPaymentPromptDetails
+            {
+                AccountIndex = newAccount.AccountIndex,
+                InvoiceSettledConfirmationThreshold = existing?.InvoiceSettledConfirmationThreshold
+            });
+            await _StoreRepository.UpdateStore(storeData);
+            return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { storeId = StoreData.Id, cryptoCode });
+        }
+
+        [HttpGet("connect/{cryptoCode}")]
+        public IActionResult ImportViewOnlyWallet(string cryptoCode)
+        {
+            cryptoCode = cryptoCode.ToUpperInvariant();
+            if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.ContainsKey(cryptoCode))
+            {
+                return NotFound();
+            }
+
+            if (_MoneroRpcProvider.WalletFileExists(cryptoCode))
+            {
+                return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { storeId = StoreData.Id, cryptoCode });
+            }
+
+            return View("/Views/Monero/ImportViewOnlyWallet.cshtml", new MoneroLikePaymentMethodViewModel { CryptoCode = cryptoCode });
+        }
+
+        [HttpPost("connect/{cryptoCode}")]
+        public async Task<IActionResult> ImportViewOnlyWallet(MoneroLikePaymentMethodViewModel viewModel, string cryptoCode)
+        {
+            cryptoCode = cryptoCode.ToUpperInvariant();
+
+            if (string.IsNullOrEmpty(viewModel.PrimaryAddress))
+            {
+                ModelState.AddModelError(nameof(viewModel.PrimaryAddress), StringLocalizer["The primary address is required to create a new wallet."]);
+            }
+
+            if (string.IsNullOrEmpty(viewModel.PrivateViewKey))
+            {
+                ModelState.AddModelError(nameof(viewModel.PrivateViewKey), StringLocalizer["The private view key is required to create a new wallet."]);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                viewModel.CryptoCode = cryptoCode;
+                return View("/Views/Monero/ImportViewOnlyWallet.cshtml", viewModel);
+            }
+
+            if (_MoneroRpcProvider.Summaries.TryGetValue(cryptoCode, out var summary))
+            {
+                if (summary.WalletAvailable)
+                {
+                    TempData.SetStatusMessageModel(new StatusMessageModel
+                    {
+                        Severity = StatusMessageModel.StatusSeverity.Error,
+                        Message = StringLocalizer["There is already an active wallet configured for {0}. Replacing it would break any existing invoices!", cryptoCode].Value
+                    });
+                    return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod),
+                        new { storeId = StoreData.Id, cryptoCode });
+                }
+            }
+            try
+            {
+                await _MoneroRpcProvider.WalletRpcClients[cryptoCode].SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys", new GenerateFromKeysRequest
+                {
+                    PrimaryAddress = viewModel.PrimaryAddress,
+                    PrivateViewKey = viewModel.PrivateViewKey,
+                    WalletFileName = "wallet",
+                    RestoreHeight = viewModel.RestoreHeight,
+                    Password = ""
+                });
+            }
+            catch (Exception ex)
+            {
+                ModelState.AddModelError(string.Empty, StringLocalizer["Could not generate view wallet from keys: {0}", ex.Message]);
+                viewModel.CryptoCode = cryptoCode;
+                return View("/Views/Monero/ImportViewOnlyWallet.cshtml", viewModel);
+            }
+
+            await _MoneroRpcProvider.UpdateSummary(cryptoCode);
+
+            TempData.SetStatusMessageModel(new StatusMessageModel
+            {
+                Severity = StatusMessageModel.StatusSeverity.Success,
+                Message = StringLocalizer["View-only wallet created and now active"].Value
+            });
+            return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { storeId = StoreData.Id, cryptoCode });
+        }
+
+        [HttpGet("setup/{cryptoCode}")]
+        public IActionResult WalletSetup(string cryptoCode)
+        {
+            cryptoCode = cryptoCode.ToUpperInvariant();
+            if (!_MoneroLikeConfiguration.MoneroLikeConfigurationItems.ContainsKey(cryptoCode))
+            {
+                return NotFound();
+            }
+
+            if (_MoneroRpcProvider.WalletFileExists(cryptoCode))
+            {
+                return RedirectToAction(nameof(GetStoreMoneroLikePaymentMethod), new { storeId = StoreData.Id, cryptoCode });
+            }
+
+            return View("/Views/Monero/WalletSetup.cshtml", new MoneroLikePaymentMethodViewModel { CryptoCode = cryptoCode });
         }
 
         public class MoneroLikePaymentMethodListViewModel
@@ -284,7 +348,6 @@ namespace BTCPayServer.Plugins.Monero.Controllers
             public bool Enabled { get; set; }
 
             public IEnumerable<SelectListItem> Accounts { get; set; }
-            public bool WalletFileFound { get; set; }
             [Display(Name = "Primary Public Address")]
             public string PrimaryAddress { get; set; }
             [Display(Name = "Private View Key")]

--- a/Plugins/Monero/Services/MoneroRpcProvider.cs
+++ b/Plugins/Monero/Services/MoneroRpcProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -69,6 +70,17 @@ namespace BTCPayServer.Plugins.Monero.Services
             return !_moneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode, out var configItem)
                 ? null
                 : configItem.WalletDirectory;
+        }
+
+        public bool WalletFileExists(string cryptoCode)
+        {
+            var walletDir = GetWalletDirectory(cryptoCode);
+            if (walletDir is null)
+            {
+                return false;
+            }
+
+            return File.Exists(Path.Combine(walletDir, "wallet.keys"));
         }
 
         public async Task<MoneroLikeSummary> UpdateSummary(string cryptoCode)

--- a/Plugins/Monero/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml
+++ b/Plugins/Monero/Views/Monero/GetStoreMoneroLikePaymentMethod.cshtml
@@ -3,7 +3,7 @@
 @model MoneroLikePaymentMethodViewModel
 
 @{
-    ViewData.SetActivePage(Model.CryptoCode, StringLocalizer["{0} Settings", Model.CryptoCode], Model.CryptoCode);
+    ViewData.SetLayoutModel(new LayoutModel(Model.CryptoCode, StringLocalizer["{0} Settings", Model.CryptoCode]));
     Layout = "_Layout";
 }
 
@@ -28,43 +28,12 @@
             </div>
         }
 
-        @if (Model.Summary?.WalletHeight is null or 0L)
-        {
-            <form method="post" asp-action="GetStoreMoneroLikePaymentMethod"
-                  asp-route-storeId="@Context.GetRouteValue("storeId")"
-                  asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")"
-                  class="mt-4">
-
-                <div class="card my-2">
-                    <h3 class="card-title p-2">Set View-Only Wallet Details</h3>
-
-                    <div class="form-group p-2">
-                        <label asp-for="PrimaryAddress" class="form-label">Wallet Primary Address</label>
-                        <input type="text" class="form-control" asp-for="PrimaryAddress" required>
-                        <span asp-validation-for="PrimaryAddress" class="text-danger"></span>
-                    </div>
-                    <div class="form-group p-2">
-                        <label asp-for="PrivateViewKey" class="form-label">Wallet Private View Key</label>
-                        <input type="text" class="form-control" asp-for="PrivateViewKey" required>
-                        <span asp-validation-for="PrivateViewKey" class="text-danger"></span>
-                    </div>
-                    <div class="form-group p-2">
-                        <label asp-for="RestoreHeight" class="form-label">Restore Height (Block Height)</label>
-                        <input type="number" class="form-control" asp-for="RestoreHeight" required>
-                        <span asp-validation-for="RestoreHeight" class="text-danger"></span>
-                    </div>
-                    <div class="card-footer text-right">
-                        <button name="command" value="set-wallet-details" class="btn btn-secondary" type="submit">Set Wallet Details</button>
-                    </div>
-                </div>
-            </form>
-        }
         @if (Model.Summary?.WalletHeight is not null and not 0L)
         {
             <form method="post" asp-action="GetStoreMoneroLikePaymentMethod"
                   asp-route-storeId="@Context.GetRouteValue("storeId")"
                   asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")"
-                  class="mt-4" enctype="multipart/form-data">
+                  class="mt-4">
 
                 <input type="hidden" asp-for="CryptoCode"/>
                 <div class="form-group">
@@ -83,7 +52,8 @@
                 <div class="form-group">
                     <div class="input-group my-3">
                         <input type="text" class="form-control" placeholder="@StringLocalizer["New account label"]" asp-for="NewAccountLabel">
-                        <button name="command" value="add-account" class="input-group-text btn btn-secondary" type="submit">Add account</button>
+                        <button type="submit" id="AddAccountButton" asp-action="AddAccount" asp-route-storeId="@Context.GetRouteValue("storeId")"
+                                asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")" class="input-group-text btn btn-secondary">Add account</button>
                     </div>
                 </div>
 

--- a/Plugins/Monero/Views/Monero/ImportViewOnlyWallet.cshtml
+++ b/Plugins/Monero/Views/Monero/ImportViewOnlyWallet.cshtml
@@ -1,0 +1,59 @@
+@model BTCPayServer.Plugins.Monero.Controllers.UIMoneroLikeStoreController.MoneroLikePaymentMethodViewModel
+
+@{
+    Layout = "_LayoutWalletSetup";
+    ViewData.SetLayoutModel(new LayoutModel(Model.CryptoCode, StringLocalizer["Connect {0} Wallet", Model.CryptoCode]));
+}
+
+@section PageFootContent {
+    @await Html.PartialAsync("_ValidationScriptsPartial")
+}
+
+<h2 class="text-center mb-4" text-translate="true">Connect your wallet</h2>
+
+@if (!ViewContext.ModelState.IsValid)
+{
+    <div asp-validation-summary="All" class="alert alert-danger"></div>
+}
+
+<form method="post" asp-action="ImportViewOnlyWallet" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-cryptoCode="@Context.GetRouteValue("cryptoCode")">
+    <div class="form-group">
+        <label asp-for="PrimaryAddress" class="form-label">Wallet Primary Address</label>
+        <input type="text" class="form-control" asp-for="PrimaryAddress" required placeholder="Enter your Monero wallet address">
+        <span asp-validation-for="PrimaryAddress" class="text-danger"></span>
+    </div>
+
+    <div class="form-group">
+        <label asp-for="PrivateViewKey" class="form-label">Private View Key</label>
+        <input type="text" class="form-control" asp-for="PrivateViewKey" required placeholder="Enter your private view key">
+        <span asp-validation-for="PrivateViewKey" class="text-danger"></span>
+    </div>
+
+    <div class="form-group">
+        <label asp-for="RestoreHeight" class="form-label">Restore Height (Block Height)</label>
+        <input type="number" class="form-control" asp-for="RestoreHeight" required placeholder="0">
+        <div class="form-text">Use 0 to scan from the beginning, or use a block height close to when your wallet was created to speed up syncing</div>
+        <span asp-validation-for="RestoreHeight" class="text-danger"></span>
+    </div>
+
+    <div class="alert alert-info mt-4">
+        <vc:icon symbol="info" />
+        <strong>Note:</strong> BTCPay Server will create a view-only wallet using your private view key.
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-12">
+            <button id="ConnectWalletButton" class="btn btn-primary btn-lg w-100" type="submit">
+                Connect Wallet
+            </button>
+        </div>
+    </div>
+
+    <div class="row mt-3">
+        <div class="col-12 text-center">
+            <a asp-controller="UIMoneroLikeStore" asp-action="WalletSetup" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-cryptoCode="@Model.CryptoCode" class="btn btn-link">
+                <vc:icon symbol="arrow-left" /> Back to setup options
+            </a>
+        </div>
+    </div>
+</form>

--- a/Plugins/Monero/Views/Monero/WalletSetup.cshtml
+++ b/Plugins/Monero/Views/Monero/WalletSetup.cshtml
@@ -1,0 +1,41 @@
+@model BTCPayServer.Plugins.Monero.Controllers.UIMoneroLikeStoreController.MoneroLikePaymentMethodViewModel
+
+@{
+    Layout = "_LayoutWalletSetup";
+    ViewData.SetLayoutModel(new LayoutModel(Model.CryptoCode, StringLocalizer["Setup {0} Wallet", Model.CryptoCode]));
+}
+
+<h1 class="text-center" text-translate="true">Let's get started</h1>
+<br>
+<div class="mt-5">
+    <h3 class="my-4" text-translate="true">I have a wallet</h3>
+    <div class="list-group">
+        <a asp-controller="UIMoneroLikeStore" asp-action="ImportViewOnlyWallet" asp-route-storeId="@Context.GetRouteValue("storeId")" asp-route-cryptoCode="@Model.CryptoCode" id="ConnectWalletLink" class="list-group-item list-group-item-action">
+            <div class="image">
+                <vc:icon symbol="wallet-existing"/>
+            </div>
+            <div class="content">
+                <h4 text-translate="true">Connect a wallet</h4>
+                <p class="mb-0 text-secondary" text-translate="true">Connect your Monero wallet using a view key</p>
+            </div>
+            <vc:icon symbol="caret-right" />
+        </a>
+    </div>
+</div>
+
+<br>
+<div class="mt-5">
+    <h3 class="my-4" text-translate="true">I don't have a wallet</h3>
+    <div class="list-group">
+        <a href="https://www.getmonero.org/resources/user-guides/view_only.html" target="_blank" rel="noopener noreferrer" id="CreateWalletLink" class="list-group-item list-group-item-action">
+            <div class="image">
+                <vc:icon symbol="wallet-new"/>
+            </div>
+            <div class="content">
+                <h4 text-translate="true">Learn how to create a Monero wallet</h4>
+                <p class="mb-0 text-secondary" text-translate="true">BTCPayServer needs a view-only wallet to generate invoices.</p>
+            </div>
+            <vc:icon symbol="caret-right"/>
+        </a>
+    </div>
+</div>

--- a/Plugins/Monero/Views/Shared/_LayoutWalletSetup.cshtml
+++ b/Plugins/Monero/Views/Shared/_LayoutWalletSetup.cshtml
@@ -1,0 +1,21 @@
+@{
+    Layout = "_LayoutWizard";
+}
+
+@section PageHeadContent {
+    @await RenderSectionAsync("PageHeadContent", false)
+}
+
+@section PageFootContent {
+    @await RenderSectionAsync("PageFootContent", false)
+}
+
+@section Navbar {
+    @await RenderSectionAsync("Navbar", false)
+
+    <a asp-controller="UIStores" asp-action="Dashboard" asp-route-storeId="@Context.GetRouteValue("storeId")" class="cancel">
+        <vc:icon symbol="cross" />
+    </a>
+}
+
+@RenderBody()

--- a/Plugins/Monero/Views/_ViewImports.cshtml
+++ b/Plugins/Monero/Views/_ViewImports.cshtml
@@ -1,4 +1,4 @@
-﻿@using Microsoft.AspNetCore.Identity
+@using Microsoft.AspNetCore.Identity
 @using BTCPayServer
 @using BTCPayServer.Abstractions.Services
 @using BTCPayServer.Views
@@ -10,6 +10,7 @@
 @using BTCPayServer.Data
 @using Microsoft.AspNetCore.Routing;
 @using BTCPayServer.Abstractions.Extensions;
+@using BTCPayServer.Abstractions.Models;
 @inject Microsoft.AspNetCore.Mvc.Localization.ViewLocalizer ViewLocalizer
 @inject Microsoft.Extensions.Localization.IStringLocalizer StringLocalizer
 @inject Safe Safe


### PR DESCRIPTION
These changes introduce a dedicated flow for configuring a monero wallet with view key

Wallet Setup Intro:
<img width="1052" height="672" alt="WalletSetupIntro" src="https://github.com/user-attachments/assets/427c744c-3225-4096-be8d-a9344c051a01" />

Connect Wallet via view key:
<img width="1125" height="691" alt="ConnectWallet" src="https://github.com/user-attachments/assets/e92eee9e-dd09-4d44-ad0b-6b29448dfa82" />

Included the following new routes:

1. `/setup/{cryptoCode}` route for the wallet setup page
2. `/connect/{cryptoCode}` flow for creating a view-only wallet
3. `/accounts/{cryptoCode}` to create accounts