### PR TITLE
Switch to private testnet and upgrade

### DIFF
--- a/BTCPayServer.Plugins.IntegrationTests/Monero/IntegrationTestUtils.cs
+++ b/BTCPayServer.Plugins.IntegrationTests/Monero/IntegrationTestUtils.cs
@@ -243,8 +243,8 @@ public static class IntegrationTestUtils
             @params = new
             {
                 address =
-                    "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L",
-                viewkey = "1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e",
+                    "9yEzCbcYdg6MqZ5AkEh8V3YCriyN1tvmtWEHdBEUHkF6D6kN1MMD2Kd2QVWoTY67aNHNYKMUP3xfteLS2QNavJxpJdx6mWj",
+                viewkey = "1f4668e8c1979b4c7dae13dc149fd95cd7ff2883becffe160c21f9e02c821c08",
                 filename = "wallet",
                 restore_height = 0,
                 password

--- a/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
+++ b/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
@@ -40,9 +40,9 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
         await s.Page.Locator("input#PrimaryAddress")
             .FillAsync(
-                "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
+                "9yEzCbcYdg6MqZ5AkEh8V3YCriyN1tvmtWEHdBEUHkF6D6kN1MMD2Kd2QVWoTY67aNHNYKMUP3xfteLS2QNavJxpJdx6mWj");
         await s.Page.Locator("input#PrivateViewKey")
-            .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
+            .FillAsync("1f4668e8c1979b4c7dae13dc149fd95cd7ff2883becffe160c21f9e02c821c08");
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
         await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
         var message = await s.Page
@@ -121,7 +121,7 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.Page.Locator("input#PrimaryAddress")
             .FillAsync("wrongprimaryaddressfSF6ZKGFT7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
         await s.Page.Locator("input#PrivateViewKey")
-            .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
+            .FillAsync("1f4668e8c1979b4c7dae13dc149fd95cd7ff2883becffe160c21f9e02c821c08");
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
         await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
         var errorText = await s.Page
@@ -143,8 +143,8 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
                 new GenerateFromKeysRequest
                 {
                     PrimaryAddress =
-                        "43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L",
-                    PrivateViewKey = "1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e",
+                        "9yEzCbcYdg6MqZ5AkEh8V3YCriyN1tvmtWEHdBEUHkF6D6kN1MMD2Kd2QVWoTY67aNHNYKMUP3xfteLS2QNavJxpJdx6mWj",
+                    PrivateViewKey = "1f4668e8c1979b4c7dae13dc149fd95cd7ff2883becffe160c21f9e02c821c08",
                     WalletFileName = "wallet",
                     Password = ""
                 }, TestContext.Current.CancellationToken);
@@ -154,9 +154,9 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await s.CreateNewStore();
         await s.Page.Locator("a.nav-link[href*='monerolike/XMR']").ClickAsync();
         await s.Page.Locator("input#PrimaryAddress")
-            .FillAsync("43Pnj6ZKGFTJhaLhiecSFfLfr64KPJZw7MyGH73T6PTDekBBvsTAaWEUSM4bmJqDuYLizhA13jQkMRPpz9VXBCBqQQb6y5L");
+            .FillAsync("9yEzCbcYdg6MqZ5AkEh8V3YCriyN1tvmtWEHdBEUHkF6D6kN1MMD2Kd2QVWoTY67aNHNYKMUP3xfteLS2QNavJxpJdx6mWj");
         await s.Page.Locator("input#PrivateViewKey")
-            .FillAsync("1bfa03b0c78aa6bc8292cf160ec9875657d61e889c41d0ebe5c54fd3a2c4b40e");
+            .FillAsync("1f4668e8c1979b4c7dae13dc149fd95cd7ff2883becffe160c21f9e02c821c08");
         await s.Page.Locator("input#RestoreHeight").FillAsync("0");
         await s.Page.ClickAsync("button[name='command'][value='set-wallet-details']");
         var errorText = await s.Page

--- a/BTCPayServer.Plugins.IntegrationTests/docker-compose.yml
+++ b/BTCPayServer.Plugins.IntegrationTests/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       TESTS_POSTGRES: User ID=postgres;Include Error Detail=true;Host=postgres;Port=5432;Database=btcpayserver
       TESTS_HOSTNAME: tests
       TESTS_INCONTAINER: "true"
-      BTCPAY_XMR_DAEMON_URI: http://monerod:18081
+      BTCPAY_XMR_DAEMON_URI: http://node_1:18081
       BTCPAY_XMR_WALLET_DAEMON_URI: http://xmr_wallet:18082
       BTCPAY_XMR_WALLET_DAEMON_WALLETDIR: /wallet
       BTCPAY_NODEFAULTCHAIN: "true"
@@ -23,37 +23,91 @@ services:
 
   # The dev container is not used, it is just handy to run `docker-compose up dev` to start all services
   dev:
-    image: alpine:3.21
+    image: alpine:3.23.5
     container_name: dev
     command: [ "/bin/sh", "-c", "trap : TERM INT; while :; do echo Ready to code and debug like a rockstar!!!; sleep 2073600; done & wait" ]
     depends_on:
       - postgres
       - xmr_wallet
 
-  monerod:
+  node_1:
     image: btcpayserver/monero:0.18.4.3
-    restart: unless-stopped
-    container_name: monerod
-    command: monerod --fixed-difficulty 1 --log-level=2 --rpc-bind-ip=0.0.0.0 --confirm-external-bind --rpc-bind-port=18081 --block-notify="/bin/sh ./scripts/notifier.sh -k -X GET https://host.docker.internal:14142/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s" --regtest --no-igd --hide-my-port --offline --non-interactive
+    container_name: node_1
+    command: [
+      "monerod",
+      "--fixed-difficulty=150",
+      "--p2p-bind-ip=0.0.0.0",
+      "--p2p-bind-port=18080",
+      "--rpc-bind-port=18081",
+      "--log-level=2",
+      "--rpc-bind-ip=0.0.0.0",
+      "--confirm-external-bind",
+      "--add-exclusive-node=node_2:28080",
+      "--testnet",
+      "--no-igd",
+      "--hide-my-port",
+      "--non-interactive"
+    ]
     volumes:
-      - xmr_data:/data
+      - xmr_node_1_data:/data
     ports:
+      - "18080:18080"
       - "18081:18081"
+
+  node_2:
+    image: btcpayserver/monero:0.18.4.3
+    container_name: node_2
+    command: [
+      "monerod",
+      "--fixed-difficulty=150",
+      "--p2p-bind-ip=0.0.0.0",
+      "--p2p-bind-port=28080",
+      "--rpc-bind-port=28081",
+      "--log-level=2",
+      "--rpc-bind-ip=0.0.0.0",
+      "--confirm-external-bind",
+      "--block-notify=/bin/sh ./scripts/notifier.sh -k -X GET https://host.docker.internal:14142/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s",
+      "--testnet",
+      "--add-exclusive-node=node_1:18080",
+      "--no-igd",
+      "--hide-my-port",
+      "--non-interactive"
+    ]
+    volumes:
+      - xmr_node_2_data:/data
+    ports:
+      - "28080:28080"
+      - "28081:28081"
+    depends_on:
+      - node_1
 
   xmr_wallet:
     image: btcpayserver/monero:0.18.4.3
-    restart: unless-stopped
     container_name: xmr_wallet
-    command: monero-wallet-rpc --log-level 2 --allow-mismatched-daemon-version --rpc-bind-ip=0.0.0.0 --disable-rpc-login --confirm-external-bind --rpc-bind-port=18082 --non-interactive --trusted-daemon --daemon-address=monerod:18081 --wallet-dir=/wallet --tx-notify="/bin/sh ./scripts/notifier.sh -k -X GET https://host.docker.internal:14142/monerolikedaemoncallback/tx?cryptoCode=xmr&hash=%s"
+    command: [
+      "monero-wallet-rpc",
+      "--log-level=2",
+      "--rpc-bind-ip=0.0.0.0",
+      "--testnet",
+      "--disable-rpc-login",
+      "--confirm-external-bind",
+      "--rpc-bind-port=18082",
+      "--non-interactive",
+      "--trusted-daemon",
+      "--daemon-address=node_2:28081",
+      "--wallet-dir=/wallet",
+      "--tx-notify=/bin/sh ./scripts/notifier.sh -k -X GET https://host.docker.internal:14142/monerolikedaemoncallback/tx?cryptoCode=xmr&hash=%s"
+    ]
     ports:
       - "18082:18082"
     volumes:
       - xmr_wallet:/wallet
     depends_on:
-      - monerod
+      - node_1
+      - node_2
 
   postgres:
-    image: postgres:17.4
+    image: postgres:18.4
     container_name: postgres
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
@@ -63,5 +117,6 @@ services:
       - "5432"
 
 volumes:
-  xmr_data:
+  xmr_node_1_data:
+  xmr_node_2_data:
   xmr_wallet:


### PR DESCRIPTION
https://moneroexamples.github.io/private-testnet/

related to: https://github.com/btcpay-monero/monero-csharp/pull/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Monero integration test wallet data and RPC inputs to use new hardcoded key material.
  * Enhanced Monero integration test infrastructure to support a two-daemon topology rather than a single daemon.
  * Adjusted wallet-to-daemon connectivity and test environment settings to match the new multi-node setup.
  * Refreshed test service configuration, including an updated Postgres image, and split Monero node data volumes for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->