### PR TITLE
Fix Monero network fee calculation

### DIFF
--- a/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
+++ b/BTCPayServer.Plugins.IntegrationTests/Monero/MoneroPluginIntegrationTest.cs
@@ -264,7 +264,7 @@ public class MoneroPluginIntegrationTest(ITestOutputHelper helper) : MoneroInteg
         await using var s = CreatePlaywrightTester();
         await s.StartAsync();
 
-        MoneroRpcProvider moneroRpcProvider = s.Server.PayTester.GetService<MoneroRpcProvider>();
+        IMoneroRpcProvider moneroRpcProvider = s.Server.PayTester.GetService<IMoneroRpcProvider>();
         await moneroRpcProvider.WalletRpcClients["XMR"]
             .SendCommandAsync<GenerateFromKeysRequest, GenerateFromKeysResponse>("generate_from_keys",
                 new GenerateFromKeysRequest

--- a/BTCPayServer.Plugins.UnitTests/Monero/Payments/MoneroFeeCalculationTests.cs
+++ b/BTCPayServer.Plugins.UnitTests/Monero/Payments/MoneroFeeCalculationTests.cs
@@ -19,28 +19,49 @@ namespace BTCPayServer.Plugins.UnitTests.Monero.Payments;
 
 public class MoneroFeeCalculationTests
 {
-    // Mainnet get_fee_estimate stub from the RPC example:
-    // { "fee": 20000, "fees": [20000,80000,320000,4000000], "quantization_mask": 10000 }
-    private static GetFeeEstimateResponse MainnetFeeStub() => new()
-    {
-        Fee = 20000,
-        Fees = [20000, 80000, 320000, 4000000],
-        QuantizationMask = 10000
-    };
-
     [Fact]
-    public async Task ConfigurePrompt_ShouldConfigurePromptWithReservedAddress()
+    public async Task ShouldCalculateFeeFromFeeEstimate()
     {
         // Given
-        MoneroLikeSpecificBtcPayNetwork network = new() { CryptoCode = "XMR", Divisibility = 12 };
+        var handler = CreateHandler();
 
-        Mock<IMoneroRpcProvider> rpcProvider = new();
-        rpcProvider.Setup(x => x.IsConfigured("XMR")).Returns(true);
-        rpcProvider.Setup(x => x.IsAvailable("XMR")).Returns(true);
+        // Mainnet get_fee_estimate stub:  { "fee": 20000, "fees": [20000,80000,320000,4000000], "quantization_mask": 10000 }
+        var context = CreateContext(handler,
+            new GetFeeEstimateResponse
+            {
+                Fee = 20000,
+                Fees = [20000, 80000, 320000, 4000000],
+                QuantizationMask = 10000
+            });
 
-        MoneroLikePaymentMethodHandler handler = new(network, rpcProvider.Object);
+        // When
+        await handler.ConfigurePrompt(context);
 
-        var context = new PaymentMethodContext(
+        // Then
+        Assert.Equal(0.000030000000m, context.Prompt.PaymentMethodFee);
+    }
+
+    [Fact]
+    public async Task ShouldRoundFeeUpToNonDivisibleQuantizationMask()
+    {
+        // Given
+        var handler = CreateHandler();
+
+        var context = CreateContext(handler,
+            new GetFeeEstimateResponse { Fee = 7874, Fees = [7874, 31496, 125984, 1574800], QuantizationMask = 10000 });
+
+        // When
+        await handler.ConfigurePrompt(context);
+
+        // Then 7874 * 1500 = 11,811,000 -> rounded up to nearest multiple of 10000 -> 11,820,000
+        Assert.Equal(0.000011820000m, context.Prompt.PaymentMethodFee);
+    }
+
+    private static PaymentMethodContext CreateContext(
+        MoneroLikePaymentMethodHandler handler,
+        GetFeeEstimateResponse feeEstimate)
+    {
+        return new PaymentMethodContext(
             new StoreData(),
             new StoreBlob(),
             JObject.FromObject(new MoneroPaymentPromptDetails
@@ -54,16 +75,22 @@ public class MoneroFeeCalculationTests
         {
             State = new MoneroLikePaymentMethodHandler.Prepare
             {
-                GetFeeRate = Task.FromResult(MainnetFeeStub()),
+                GetFeeRate = Task.FromResult(feeEstimate),
                 ReserveAddress =
                     s => Task.FromResult(new CreateAddressResponse { Address = "fake-xmr-address", Index = 0 }),
                 AccountIndex = 0
             }
         };
+    }
 
-        // When
-        await handler.ConfigurePrompt(context);
-        // Then fees are 1.9E-09 XMR
-        Assert.Equal(0.000000001900m, context.Prompt.PaymentMethodFee);
+    private static MoneroLikePaymentMethodHandler CreateHandler()
+    {
+        var network = new MoneroLikeSpecificBtcPayNetwork { CryptoCode = "XMR", Divisibility = 12 };
+
+        Mock<IMoneroRpcProvider> rpcProvider = new();
+        rpcProvider.Setup(x => x.IsConfigured("XMR")).Returns(true);
+        rpcProvider.Setup(x => x.IsAvailable("XMR")).Returns(true);
+
+        return new MoneroLikePaymentMethodHandler(network, rpcProvider.Object);
     }
 }

--- a/BTCPayServer.Plugins.UnitTests/Monero/Payments/MoneroFeeCalculationTests.cs
+++ b/BTCPayServer.Plugins.UnitTests/Monero/Payments/MoneroFeeCalculationTests.cs
@@ -1,0 +1,69 @@
+using BTCPayServer.Data;
+using BTCPayServer.Logging;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.Monero;
+using BTCPayServer.Plugins.Monero.Payments;
+using BTCPayServer.Plugins.Monero.Services;
+using BTCPayServer.Services.Invoices;
+
+using Monero.Daemon.Common;
+using Monero.Wallet.Rpc;
+
+using Moq;
+
+using Newtonsoft.Json.Linq;
+
+using Xunit;
+
+namespace BTCPayServer.Plugins.UnitTests.Monero.Payments;
+
+public class MoneroFeeCalculationTests
+{
+    // Mainnet get_fee_estimate stub from the RPC example:
+    // { "fee": 20000, "fees": [20000,80000,320000,4000000], "quantization_mask": 10000 }
+    private static GetFeeEstimateResponse MainnetFeeStub() => new()
+    {
+        Fee = 20000,
+        Fees = [20000, 80000, 320000, 4000000],
+        QuantizationMask = 10000
+    };
+
+    [Fact]
+    public async Task ConfigurePrompt_ShouldConfigurePromptWithReservedAddress()
+    {
+        // Given
+        MoneroLikeSpecificBtcPayNetwork network = new() { CryptoCode = "XMR", Divisibility = 12 };
+
+        Mock<IMoneroRpcProvider> rpcProvider = new();
+        rpcProvider.Setup(x => x.IsConfigured("XMR")).Returns(true);
+        rpcProvider.Setup(x => x.IsAvailable("XMR")).Returns(true);
+
+        MoneroLikePaymentMethodHandler handler = new(network, rpcProvider.Object);
+
+        var context = new PaymentMethodContext(
+            new StoreData(),
+            new StoreBlob(),
+            JObject.FromObject(new MoneroPaymentPromptDetails
+            {
+                AccountIndex = 0,
+                InvoiceSettledConfirmationThreshold = 10
+            }),
+            handler,
+            new InvoiceEntity { Currency = "USD" },
+            new InvoiceLogs())
+        {
+            State = new MoneroLikePaymentMethodHandler.Prepare
+            {
+                GetFeeRate = Task.FromResult(MainnetFeeStub()),
+                ReserveAddress =
+                    s => Task.FromResult(new CreateAddressResponse { Address = "fake-xmr-address", Index = 0 }),
+                AccountIndex = 0
+            }
+        };
+
+        // When
+        await handler.ConfigurePrompt(context);
+        // Then fees are 1.9E-09 XMR
+        Assert.Equal(0.000000001900m, context.Prompt.PaymentMethodFee);
+    }
+}

--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <Product>Monero</Product>
     <Description>This plugin extends BTCPay Server to enable users to receive payments via Monero.</Description>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 

--- a/Plugins/Monero/BTCPayServer.Plugins.Monero.json
+++ b/Plugins/Monero/BTCPayServer.Plugins.Monero.json
@@ -1,7 +1,7 @@
 {
   "Identifier": "BTCPayServer.Plugins.Monero",
   "Name": "Monero",
-  "Version": "1.3.3",
+  "Version": "1.3.4",
   "Description": "This plugin extends BTCPay Server to enable users to receive payments via Monero.",
   "SystemPlugin": false,
   "Dependencies": [

--- a/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
+++ b/Plugins/Monero/Controllers/MoneroLikeStoreController.cs
@@ -34,13 +34,13 @@ namespace BTCPayServer.Plugins.Monero.Controllers
     {
         private readonly MoneroLikeConfiguration _MoneroLikeConfiguration;
         private readonly StoreRepository _StoreRepository;
-        private readonly MoneroRpcProvider _MoneroRpcProvider;
+        private readonly IMoneroRpcProvider _MoneroRpcProvider;
         private readonly PaymentMethodHandlerDictionary _handlers;
         private readonly ILogger<UIMoneroLikeStoreController> _logger;
         private IStringLocalizer StringLocalizer { get; }
 
         public UIMoneroLikeStoreController(MoneroLikeConfiguration moneroLikeConfiguration,
-            StoreRepository storeRepository, MoneroRpcProvider moneroRpcProvider,
+            StoreRepository storeRepository, IMoneroRpcProvider moneroRpcProvider,
             PaymentMethodHandlerDictionary handlers,
             IStringLocalizer stringLocalizer,
             ILogger<UIMoneroLikeStoreController> logger)

--- a/Plugins/Monero/MoneroPlugin.cs
+++ b/Plugins/Monero/MoneroPlugin.cs
@@ -77,7 +77,7 @@ public class MoneroPlugin : BaseBTCPayServerPlugin
                     PreAuthenticate = true
                 };
             });
-        services.AddSingleton<MoneroRpcProvider>();
+        services.AddSingleton<IMoneroRpcProvider, MoneroRpcProvider>();
         services.AddHostedService<MoneroLikeSummaryUpdaterHostedService>();
         services.AddHostedService<MoneroListener>();
         services.AddHostedService<MoneroLoadUpService>();

--- a/Plugins/Monero/MoneroPlugin.cs
+++ b/Plugins/Monero/MoneroPlugin.cs
@@ -26,7 +26,7 @@ namespace BTCPayServer.Plugins.Monero;
 
 public class MoneroPlugin : BaseBTCPayServerPlugin
 {
-    public override Version Version => new(1, 3, 3);
+    public override Version Version => new(1, 3, 4);
 
     public override IBTCPayServerPlugin.PluginDependency[] Dependencies { get; } =
     [

--- a/Plugins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
+++ b/Plugins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
@@ -13,113 +13,124 @@ using Monero.Wallet.Rpc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace BTCPayServer.Plugins.Monero.Payments
+namespace BTCPayServer.Plugins.Monero.Payments;
+
+public class MoneroLikePaymentMethodHandler(
+    MoneroLikeSpecificBtcPayNetwork network,
+    IMoneroRpcProvider moneroRpcProvider)
+    : IPaymentMethodHandler
 {
-    public class MoneroLikePaymentMethodHandler : IPaymentMethodHandler
+    public JsonSerializer Serializer { get; } = BlobSerializer.CreateSerializer().Serializer;
+    public PaymentMethodId PaymentMethodId { get; } = PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode);
+
+    bool IsReady() => moneroRpcProvider.IsConfigured(network.CryptoCode) &&
+                      moneroRpcProvider.IsAvailable(network.CryptoCode);
+
+    public Task BeforeFetchingRates(PaymentMethodContext context)
     {
-        private readonly MoneroLikeSpecificBtcPayNetwork _network;
-        public MoneroLikeSpecificBtcPayNetwork Network => _network;
-        public JsonSerializer Serializer { get; }
-        private readonly MoneroRpcProvider _moneroRpcProvider;
-
-        public PaymentMethodId PaymentMethodId { get; }
-
-        public MoneroLikePaymentMethodHandler(MoneroLikeSpecificBtcPayNetwork network, MoneroRpcProvider moneroRpcProvider)
+        context.Prompt.Currency = network.CryptoCode;
+        context.Prompt.Divisibility = network.Divisibility;
+        if (context.Prompt.Activated && IsReady())
         {
-            PaymentMethodId = PaymentTypes.CHAIN.GetPaymentMethodId(network.CryptoCode);
-            _network = network;
-            Serializer = BlobSerializer.CreateSerializer().Serializer;
-            _moneroRpcProvider = moneroRpcProvider;
-        }
-        bool IsReady() => _moneroRpcProvider.IsConfigured(_network.CryptoCode) && _moneroRpcProvider.IsAvailable(_network.CryptoCode);
-
-        public Task BeforeFetchingRates(PaymentMethodContext context)
-        {
-            context.Prompt.Currency = _network.CryptoCode;
-            context.Prompt.Divisibility = _network.Divisibility;
-            if (context.Prompt.Activated && IsReady())
+            var supportedPaymentMethod = ParsePaymentMethodConfig(context.PaymentMethodConfig);
+            var walletClient = moneroRpcProvider.WalletRpcClients[network.CryptoCode];
+            var daemonClient = moneroRpcProvider.DaemonRpcClients[network.CryptoCode];
+            try
             {
-                var supportedPaymentMethod = ParsePaymentMethodConfig(context.PaymentMethodConfig);
-                var walletClient = _moneroRpcProvider.WalletRpcClients[_network.CryptoCode];
-                var daemonClient = _moneroRpcProvider.DaemonRpcClients[_network.CryptoCode];
-                try
+                context.State = new Prepare
                 {
-                    context.State = new Prepare()
-                    {
-                        GetFeeRate = daemonClient.SendCommandAsync<GetFeeEstimateRequest, GetFeeEstimateResponse>("get_fee_estimate", new GetFeeEstimateRequest()),
-                        ReserveAddress = s => walletClient.SendCommandAsync<CreateAddressRequest, CreateAddressResponse>("create_address", new CreateAddressRequest() { Label = $"btcpay invoice #{s}", AccountIndex = supportedPaymentMethod.AccountIndex }),
-                        AccountIndex = supportedPaymentMethod.AccountIndex
-                    };
-                }
-                catch (Exception ex)
-                {
-                    context.Logs.Write($"Error in BeforeFetchingRates: {ex.Message}", InvoiceEventData.EventSeverity.Error);
-                }
+                    GetFeeRate =
+                        daemonClient.SendCommandAsync<GetFeeEstimateRequest, GetFeeEstimateResponse>(
+                            "get_fee_estimate", new GetFeeEstimateRequest()),
+                    ReserveAddress = s =>
+                        walletClient.SendCommandAsync<CreateAddressRequest, CreateAddressResponse>(
+                            "create_address",
+                            new CreateAddressRequest
+                            {
+                                Label = $"btcpay invoice #{s}",
+                                AccountIndex = supportedPaymentMethod.AccountIndex
+                            }),
+                    AccountIndex = supportedPaymentMethod.AccountIndex
+                };
             }
-            return Task.CompletedTask;
-        }
-
-        public async Task ConfigurePrompt(PaymentMethodContext context)
-        {
-            if (!_moneroRpcProvider.IsConfigured(_network.CryptoCode))
+            catch (Exception ex)
             {
-                throw new PaymentMethodUnavailableException($"BTCPAY_XMR_WALLET_DAEMON_URI or BTCPAY_XMR_DAEMON_URI isn't configured");
+                context.Logs.Write($"Error in BeforeFetchingRates: {ex.Message}",
+                    InvoiceEventData.EventSeverity.Error);
             }
-
-            if (!_moneroRpcProvider.IsAvailable(_network.CryptoCode) || context.State is not Prepare moneroPrepare)
-            {
-                throw new PaymentMethodUnavailableException($"Node or wallet not available");
-            }
-
-            var invoice = context.InvoiceEntity;
-            var feeRatePerKb = await moneroPrepare.GetFeeRate;
-            var address = await moneroPrepare.ReserveAddress(invoice.Id);
-
-            var feeRatePerByte = feeRatePerKb.Fee / 1024;
-            var details = new MoneroLikeOnChainPaymentMethodDetails()
-            {
-                AccountIndex = moneroPrepare.AccountIndex,
-                AddressIndex = address.Index,
-                InvoiceSettledConfirmationThreshold = ParsePaymentMethodConfig(context.PaymentMethodConfig).InvoiceSettledConfirmationThreshold
-            };
-            context.Prompt.Destination = address.Address;
-            context.Prompt.PaymentMethodFee = MoneroMoney.Convert(feeRatePerByte * 100);
-            context.Prompt.Details = JObject.FromObject(details, Serializer);
-            context.TrackedDestinations.Add(address.Address);
-        }
-        private MoneroPaymentPromptDetails ParsePaymentMethodConfig(JToken config)
-        {
-            return config.ToObject<MoneroPaymentPromptDetails>(Serializer) ?? throw new FormatException($"Invalid {nameof(MoneroLikePaymentMethodHandler)}");
-        }
-        object IPaymentMethodHandler.ParsePaymentMethodConfig(JToken config)
-        {
-            return ParsePaymentMethodConfig(config);
         }
 
-        class Prepare
-        {
-            public Task<GetFeeEstimateResponse> GetFeeRate;
-            public Func<string, Task<CreateAddressResponse>> ReserveAddress;
+        return Task.CompletedTask;
+    }
 
-            public long AccountIndex { get; internal set; }
-        }
-
-        public MoneroLikeOnChainPaymentMethodDetails ParsePaymentPromptDetails(JToken details)
+    public async Task ConfigurePrompt(PaymentMethodContext context)
+    {
+        if (!moneroRpcProvider.IsConfigured(network.CryptoCode))
         {
-            return details.ToObject<MoneroLikeOnChainPaymentMethodDetails>(Serializer);
-        }
-        object IPaymentMethodHandler.ParsePaymentPromptDetails(JToken details)
-        {
-            return ParsePaymentPromptDetails(details);
+            throw new PaymentMethodUnavailableException(
+                "BTCPAY_XMR_WALLET_DAEMON_URI or BTCPAY_XMR_DAEMON_URI isn't configured");
         }
 
-        public MoneroLikePaymentData ParsePaymentDetails(JToken details)
+        if (!moneroRpcProvider.IsAvailable(network.CryptoCode) || context.State is not Prepare moneroPrepare)
         {
-            return details.ToObject<MoneroLikePaymentData>(Serializer) ?? throw new FormatException($"Invalid {nameof(MoneroLikePaymentMethodHandler)}");
+            throw new PaymentMethodUnavailableException("Node or wallet not available");
         }
-        object IPaymentMethodHandler.ParsePaymentDetails(JToken details)
+
+        var invoice = context.InvoiceEntity;
+        var feeRatePerKb = await moneroPrepare.GetFeeRate;
+        var address = await moneroPrepare.ReserveAddress(invoice.Id);
+
+        var feeRatePerByte = feeRatePerKb.Fee / 1024;
+        var details = new MoneroLikeOnChainPaymentMethodDetails
         {
-            return ParsePaymentDetails(details);
-        }
+            AccountIndex = moneroPrepare.AccountIndex,
+            AddressIndex = address.Index,
+            InvoiceSettledConfirmationThreshold = ParsePaymentMethodConfig(context.PaymentMethodConfig)
+                .InvoiceSettledConfirmationThreshold
+        };
+        context.Prompt.Destination = address.Address;
+        context.Prompt.PaymentMethodFee = MoneroMoney.Convert(feeRatePerByte * 100);
+        context.Prompt.Details = JObject.FromObject(details, Serializer);
+        context.TrackedDestinations.Add(address.Address);
+    }
+
+    private MoneroPaymentPromptDetails ParsePaymentMethodConfig(JToken config)
+    {
+        return config.ToObject<MoneroPaymentPromptDetails>(Serializer) ??
+               throw new FormatException($"Invalid {nameof(MoneroLikePaymentMethodHandler)}");
+    }
+
+    object IPaymentMethodHandler.ParsePaymentMethodConfig(JToken config)
+    {
+        return ParsePaymentMethodConfig(config);
+    }
+
+    public class Prepare
+    {
+        public Task<GetFeeEstimateResponse> GetFeeRate;
+        public Func<string, Task<CreateAddressResponse>> ReserveAddress;
+
+        public long AccountIndex { get; init; }
+    }
+
+    public MoneroLikeOnChainPaymentMethodDetails ParsePaymentPromptDetails(JToken details)
+    {
+        return details.ToObject<MoneroLikeOnChainPaymentMethodDetails>(Serializer);
+    }
+
+    object IPaymentMethodHandler.ParsePaymentPromptDetails(JToken details)
+    {
+        return ParsePaymentPromptDetails(details);
+    }
+
+    public MoneroLikePaymentData ParsePaymentDetails(JToken details)
+    {
+        return details.ToObject<MoneroLikePaymentData>(Serializer) ??
+               throw new FormatException($"Invalid {nameof(MoneroLikePaymentMethodHandler)}");
+    }
+
+    object IPaymentMethodHandler.ParsePaymentDetails(JToken details)
+    {
+        return ParsePaymentDetails(details);
     }
 }

--- a/Plugins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
+++ b/Plugins/Monero/Payments/MoneroLikePaymentMethodHandler.cs
@@ -77,10 +77,9 @@ public class MoneroLikePaymentMethodHandler(
         }
 
         var invoice = context.InvoiceEntity;
-        var feeRatePerKb = await moneroPrepare.GetFeeRate;
+        var feeAtomicRatePerByte = await moneroPrepare.GetFeeRate;
         var address = await moneroPrepare.ReserveAddress(invoice.Id);
 
-        var feeRatePerByte = feeRatePerKb.Fee / 1024;
         var details = new MoneroLikeOnChainPaymentMethodDetails
         {
             AccountIndex = moneroPrepare.AccountIndex,
@@ -89,9 +88,24 @@ public class MoneroLikePaymentMethodHandler(
                 .InvoiceSettledConfirmationThreshold
         };
         context.Prompt.Destination = address.Address;
-        context.Prompt.PaymentMethodFee = MoneroMoney.Convert(feeRatePerByte * 100);
+        // Multiply by 1500 bytes, which is a reasonable approximate weight of a 1-in/2-out Monero transaction.
+        var estimatedFee = feeAtomicRatePerByte.Fee * 1500;
+        // Round up to the nearest multiple of QuantizationMask
+        var quantizedFee = RoundUpToMask(estimatedFee, feeAtomicRatePerByte.QuantizationMask);
+        context.Prompt.PaymentMethodFee = MoneroMoney.Convert(quantizedFee);
         context.Prompt.Details = JObject.FromObject(details, Serializer);
         context.TrackedDestinations.Add(address.Address);
+    }
+
+    private static long RoundUpToMask(long value, long mask)
+    {
+        if (mask <= 1)
+        {
+            return value;
+        }
+
+        var remainder = value % mask;
+        return remainder == 0 ? value : value + (mask - remainder);
     }
 
     private MoneroPaymentPromptDetails ParsePaymentMethodConfig(JToken config)

--- a/Plugins/Monero/Services/MoneroLikeSummaryUpdaterHostedService.cs
+++ b/Plugins/Monero/Services/MoneroLikeSummaryUpdaterHostedService.cs
@@ -12,13 +12,13 @@ namespace BTCPayServer.Plugins.Monero.Services
 {
     public class MoneroLikeSummaryUpdaterHostedService : IHostedService
     {
-        private readonly MoneroRpcProvider _MoneroRpcProvider;
+        private readonly IMoneroRpcProvider _MoneroRpcProvider;
         private readonly MoneroLikeConfiguration _moneroLikeConfiguration;
 
         public Logs Logs { get; }
 
         private CancellationTokenSource _Cts;
-        public MoneroLikeSummaryUpdaterHostedService(MoneroRpcProvider moneroRpcProvider, MoneroLikeConfiguration moneroLikeConfiguration, Logs logs)
+        public MoneroLikeSummaryUpdaterHostedService(IMoneroRpcProvider moneroRpcProvider, MoneroLikeConfiguration moneroLikeConfiguration, Logs logs)
         {
             _MoneroRpcProvider = moneroRpcProvider;
             _moneroLikeConfiguration = moneroLikeConfiguration;

--- a/Plugins/Monero/Services/MoneroListener.cs
+++ b/Plugins/Monero/Services/MoneroListener.cs
@@ -29,7 +29,7 @@ namespace BTCPayServer.Plugins.Monero.Services
     {
         private readonly InvoiceRepository _invoiceRepository;
         private readonly EventAggregator _eventAggregator;
-        private readonly MoneroRpcProvider _moneroRpcProvider;
+        private readonly IMoneroRpcProvider _moneroRpcProvider;
         private readonly BTCPayNetworkProvider _networkProvider;
         private readonly ILogger<MoneroListener> _logger;
         private readonly PaymentMethodHandlerDictionary _handlers;
@@ -38,7 +38,7 @@ namespace BTCPayServer.Plugins.Monero.Services
 
         public MoneroListener(InvoiceRepository invoiceRepository,
             EventAggregator eventAggregator,
-            MoneroRpcProvider moneroRpcProvider,
+            IMoneroRpcProvider moneroRpcProvider,
             BTCPayNetworkProvider networkProvider,
             ILogger<MoneroListener> logger,
             PaymentMethodHandlerDictionary handlers,

--- a/Plugins/Monero/Services/MoneroLoadUpService.cs
+++ b/Plugins/Monero/Services/MoneroLoadUpService.cs
@@ -15,9 +15,9 @@ public class MoneroLoadUpService : IHostedService
 {
     private const string CryptoCode = "XMR";
     private readonly ILogger<MoneroLoadUpService> _logger;
-    private readonly MoneroRpcProvider _moneroRpcProvider;
+    private readonly IMoneroRpcProvider _moneroRpcProvider;
 
-    public MoneroLoadUpService(ILogger<MoneroLoadUpService> logger, MoneroRpcProvider moneroRpcProvider)
+    public MoneroLoadUpService(ILogger<MoneroLoadUpService> logger, IMoneroRpcProvider moneroRpcProvider)
     {
         _moneroRpcProvider = moneroRpcProvider;
         _logger = logger;

--- a/Plugins/Monero/Services/MoneroRpcProvider.cs
+++ b/Plugins/Monero/Services/MoneroRpcProvider.cs
@@ -12,133 +12,143 @@ using Monero.Wallet.Rpc;
 
 using NBitcoin;
 
-namespace BTCPayServer.Plugins.Monero.Services
+namespace BTCPayServer.Plugins.Monero.Services;
+
+public interface IMoneroRpcProvider
 {
-    public class MoneroRpcProvider
+    bool IsConfigured(string cryptoCode);
+    bool IsAvailable(string cryptoCode);
+    string GetWalletDirectory(string cryptoCode);
+    Task CloseWallet(string cryptoCode);
+    Task<MoneroRpcProvider.MoneroLikeSummary> UpdateSummary(string cryptoCode);
+    ConcurrentDictionary<string, MoneroRpcProvider.MoneroLikeSummary> Summaries { get; }
+    ImmutableDictionary<string, MoneroRpcConnection> DaemonRpcClients { get; }
+    ImmutableDictionary<string, MoneroRpcConnection> WalletRpcClients { get; }
+}
+
+public class MoneroRpcProvider : IMoneroRpcProvider
+{
+    private readonly MoneroLikeConfiguration _moneroLikeConfiguration;
+    private readonly EventAggregator _eventAggregator;
+    public ImmutableDictionary<string, MoneroRpcConnection> DaemonRpcClients { get; }
+    public ImmutableDictionary<string, MoneroRpcConnection> WalletRpcClients { get; }
+    public ConcurrentDictionary<string, MoneroLikeSummary> Summaries { get; } = new();
+
+    public MoneroRpcProvider(MoneroLikeConfiguration moneroLikeConfiguration,
+        EventAggregator eventAggregator,
+        IHttpClientFactory httpClientFactory)
     {
-        private readonly MoneroLikeConfiguration _moneroLikeConfiguration;
-        private readonly EventAggregator _eventAggregator;
-        public ImmutableDictionary<string, MoneroRpcConnection> DaemonRpcClients;
-        public ImmutableDictionary<string, MoneroRpcConnection> WalletRpcClients;
+        _moneroLikeConfiguration = moneroLikeConfiguration;
+        _eventAggregator = eventAggregator;
+        DaemonRpcClients =
+            _moneroLikeConfiguration.MoneroLikeConfigurationItems.ToImmutableDictionary(pair => pair.Key,
+                pair => new MoneroRpcConnection(pair.Value.DaemonRpcUri, pair.Value.Username, pair.Value.Password,
+                    httpClientFactory.CreateClient($"{pair.Key}client")));
+        WalletRpcClients =
+            _moneroLikeConfiguration.MoneroLikeConfigurationItems.ToImmutableDictionary(pair => pair.Key,
+                pair => new MoneroRpcConnection(pair.Value.InternalWalletRpcUri, "", "",
+                    httpClientFactory.CreateClient($"{pair.Key}client")));
+    }
 
-        public ConcurrentDictionary<string, MoneroLikeSummary> Summaries { get; } = new();
+    public bool IsConfigured(string cryptoCode) => WalletRpcClients.ContainsKey(cryptoCode) && DaemonRpcClients.ContainsKey(cryptoCode);
+    public bool IsAvailable(string cryptoCode)
+    {
+        cryptoCode = cryptoCode.ToUpperInvariant();
+        return Summaries.ContainsKey(cryptoCode) && IsAvailable(Summaries[cryptoCode]);
+    }
 
-        public MoneroRpcProvider(MoneroLikeConfiguration moneroLikeConfiguration,
-            EventAggregator eventAggregator,
-            IHttpClientFactory httpClientFactory)
+    private bool IsAvailable(MoneroLikeSummary summary)
+    {
+        return summary.Synced &&
+               summary.WalletAvailable;
+    }
+
+    public async Task CloseWallet(string cryptoCode)
+    {
+        if (!WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
         {
-            _moneroLikeConfiguration = moneroLikeConfiguration;
-            _eventAggregator = eventAggregator;
-            DaemonRpcClients =
-                _moneroLikeConfiguration.MoneroLikeConfigurationItems.ToImmutableDictionary(pair => pair.Key,
-                    pair => new MoneroRpcConnection(pair.Value.DaemonRpcUri, pair.Value.Username, pair.Value.Password,
-                        httpClientFactory.CreateClient($"{pair.Key}client")));
-            WalletRpcClients =
-                _moneroLikeConfiguration.MoneroLikeConfigurationItems.ToImmutableDictionary(pair => pair.Key,
-                    pair => new MoneroRpcConnection(pair.Value.InternalWalletRpcUri, "", "",
-                        httpClientFactory.CreateClient($"{pair.Key}client")));
+            throw new InvalidOperationException($"Wallet RPC client not found for {cryptoCode}");
         }
 
-        public bool IsConfigured(string cryptoCode) => WalletRpcClients.ContainsKey(cryptoCode) && DaemonRpcClients.ContainsKey(cryptoCode);
-        public bool IsAvailable(string cryptoCode)
+        await walletRpcClient.SendCommandAsync<NoRequestModel, object>(
+            "close_wallet", NoRequestModel.Instance);
+    }
+
+    public string GetWalletDirectory(string cryptoCode)
+    {
+        cryptoCode = cryptoCode.ToUpperInvariant();
+        return !_moneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode, out var configItem)
+            ? null
+            : configItem.WalletDirectory;
+    }
+
+    public async Task<MoneroLikeSummary> UpdateSummary(string cryptoCode)
+    {
+        if (!DaemonRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var daemonRpcClient) ||
+            !WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
         {
-            cryptoCode = cryptoCode.ToUpperInvariant();
-            return Summaries.ContainsKey(cryptoCode) && IsAvailable(Summaries[cryptoCode]);
+            return null;
         }
 
-        private bool IsAvailable(MoneroLikeSummary summary)
+        var summary = new MoneroLikeSummary();
+        try
         {
-            return summary.Synced &&
-                   summary.WalletAvailable;
+            var daemonResult =
+                await daemonRpcClient.SendCommandAsync<NoRequestModel, MoneroDaemonInfo>("get_info",
+                    NoRequestModel.Instance);
+            summary.TargetHeight = daemonResult.TargetHeight.GetValueOrDefault(0);
+            summary.CurrentHeight = daemonResult.Height;
+            summary.DaemonVersion = daemonResult.Version;
+            summary.Restricted = daemonResult.IsRestricted;
+            summary.TargetHeight = summary.TargetHeight == 0 ? summary.CurrentHeight : summary.TargetHeight;
+            summary.Synced = !daemonResult.BusySyncing;
+            summary.UpdatedAt = DateTime.UtcNow;
+            summary.DaemonAvailable = true;
+        }
+        catch
+        {
+            summary.DaemonAvailable = false;
+        }
+        try
+        {
+            var walletResult =
+                await walletRpcClient.SendCommandAsync<NoRequestModel, GetHeightResponse>(
+                    "get_height", NoRequestModel.Instance);
+            summary.WalletHeight = walletResult.Height;
+            summary.WalletAvailable = true;
+        }
+        catch
+        {
+            summary.WalletAvailable = false;
         }
 
-        public async Task CloseWallet(string cryptoCode)
-        {
-            if (!WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
-            {
-                throw new InvalidOperationException($"Wallet RPC client not found for {cryptoCode}");
-            }
+        var changed = !Summaries.ContainsKey(cryptoCode) || IsAvailable(cryptoCode) != IsAvailable(summary);
 
-            await walletRpcClient.SendCommandAsync<NoRequestModel, object>(
-                "close_wallet", NoRequestModel.Instance);
+        Summaries.AddOrReplace(cryptoCode, summary);
+        if (changed)
+        {
+            _eventAggregator.Publish(new MoneroDaemonStateChange() { Summary = summary, CryptoCode = cryptoCode });
         }
 
-        public string GetWalletDirectory(string cryptoCode)
-        {
-            cryptoCode = cryptoCode.ToUpperInvariant();
-            return !_moneroLikeConfiguration.MoneroLikeConfigurationItems.TryGetValue(cryptoCode, out var configItem)
-                ? null
-                : configItem.WalletDirectory;
-        }
+        return summary;
+    }
 
-        public async Task<MoneroLikeSummary> UpdateSummary(string cryptoCode)
-        {
-            if (!DaemonRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var daemonRpcClient) ||
-                !WalletRpcClients.TryGetValue(cryptoCode.ToUpperInvariant(), out var walletRpcClient))
-            {
-                return null;
-            }
+    public class MoneroDaemonStateChange
+    {
+        public string CryptoCode { get; set; }
+        public MoneroLikeSummary Summary { get; set; }
+    }
 
-            var summary = new MoneroLikeSummary();
-            try
-            {
-                var daemonResult =
-                    await daemonRpcClient.SendCommandAsync<NoRequestModel, MoneroDaemonInfo>("get_info",
-                        NoRequestModel.Instance);
-                summary.TargetHeight = daemonResult.TargetHeight.GetValueOrDefault(0);
-                summary.CurrentHeight = daemonResult.Height;
-                summary.DaemonVersion = daemonResult.Version;
-                summary.Restricted = daemonResult.IsRestricted;
-                summary.TargetHeight = summary.TargetHeight == 0 ? summary.CurrentHeight : summary.TargetHeight;
-                summary.Synced = !daemonResult.BusySyncing;
-                summary.UpdatedAt = DateTime.UtcNow;
-                summary.DaemonAvailable = true;
-            }
-            catch
-            {
-                summary.DaemonAvailable = false;
-            }
-            try
-            {
-                var walletResult =
-                    await walletRpcClient.SendCommandAsync<NoRequestModel, GetHeightResponse>(
-                        "get_height", NoRequestModel.Instance);
-                summary.WalletHeight = walletResult.Height;
-                summary.WalletAvailable = true;
-            }
-            catch
-            {
-                summary.WalletAvailable = false;
-            }
-
-            var changed = !Summaries.ContainsKey(cryptoCode) || IsAvailable(cryptoCode) != IsAvailable(summary);
-
-            Summaries.AddOrReplace(cryptoCode, summary);
-            if (changed)
-            {
-                _eventAggregator.Publish(new MoneroDaemonStateChange() { Summary = summary, CryptoCode = cryptoCode });
-            }
-
-            return summary;
-        }
-
-        public class MoneroDaemonStateChange
-        {
-            public string CryptoCode { get; set; }
-            public MoneroLikeSummary Summary { get; set; }
-        }
-
-        public class MoneroLikeSummary
-        {
-            public bool Synced { get; set; }
-            public long CurrentHeight { get; set; }
-            public ulong WalletHeight { get; set; }
-            public long TargetHeight { get; set; }
-            public DateTime UpdatedAt { get; set; }
-            public bool DaemonAvailable { get; set; }
-            public string DaemonVersion { get; set; }
-            public bool Restricted { get; set; }
-            public bool WalletAvailable { get; set; }
-        }
+    public class MoneroLikeSummary
+    {
+        public bool Synced { get; set; }
+        public long CurrentHeight { get; set; }
+        public ulong WalletHeight { get; set; }
+        public long TargetHeight { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public bool DaemonAvailable { get; set; }
+        public string DaemonVersion { get; set; }
+        public bool Restricted { get; set; }
+        public bool WalletAvailable { get; set; }
     }
 }

--- a/Plugins/Monero/Services/MoneroSyncSummaryProvider.cs
+++ b/Plugins/Monero/Services/MoneroSyncSummaryProvider.cs
@@ -9,9 +9,9 @@ namespace BTCPayServer.Plugins.Monero.Services
 {
     public class MoneroSyncSummaryProvider : ISyncSummaryProvider
     {
-        private readonly MoneroRpcProvider _moneroRpcProvider;
+        private readonly IMoneroRpcProvider _moneroRpcProvider;
 
-        public MoneroSyncSummaryProvider(MoneroRpcProvider moneroRpcProvider)
+        public MoneroSyncSummaryProvider(IMoneroRpcProvider moneroRpcProvider)
         {
             _moneroRpcProvider = moneroRpcProvider;
         }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.302",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
closes https://github.com/btcpay-monero/btcpayserver-monero-plugin/pull/1

See [#1](https://github.com/btcpay-monero/btcpayserver-monero-plugin/pull/1) for prior discussion on this bug

https://docs.btcpayserver.org/FAQ/Stores/#add-network-fee-to-invoice-vary-with-mining-fees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Improved Monero payment fee calculations for more accurate payment prompts.
- Enhanced Monero wallet and RPC integration while preserving existing payment preparation and error handling.
- Updated platform components for improved compatibility.

## Tests

- Added coverage for standard Monero fee calculations and correct upward rounding when fee increments do not divide evenly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->